### PR TITLE
fix: change log s3 bucket encryption type to S3_MANAGED

### DIFF
--- a/infra/lib/constructs/cloudfront-s3-website-construct.ts
+++ b/infra/lib/constructs/cloudfront-s3-website-construct.ts
@@ -62,7 +62,7 @@ export class CloudFrontS3WebSiteConstruct extends Construct {
     props = { ...defaultProps, ...props };
 
     const accessLogsBucket = new s3.Bucket(this, "AccessLogsBucket", {
-      encryption: s3.BucketEncryption.KMS_MANAGED,
+      encryption: s3.BucketEncryption.S3_MANAGED,
       serverAccessLogsPrefix: "web-app-access-log-bucket-logs/",
       versioned: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL

--- a/infra/lib/storage-builder.ts
+++ b/infra/lib/storage-builder.ts
@@ -31,7 +31,7 @@ export interface storageResources {
 export function storageResourcesBuilder(scope: Construct): storageResources {
 
     const accessLogsBucket = new s3.Bucket(scope, "AccessLogsBucket", {
-        encryption: s3.BucketEncryption.KMS_MANAGED,
+        encryption: s3.BucketEncryption.S3_MANAGED,
         serverAccessLogsPrefix: 'access-log-bucket-logs/',
         versioned: true,
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL


### PR DESCRIPTION
Issue [#23513](https://github.com/aws/aws-cdk/issues/23513)

Description of changes: Changed log s3 buckets encryption from KMS_MANAGED to S3_MANAGED due to change in S3 allowed encryption settings relating to the 1/5/2023 S3 default encryption behavior change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
