### PR TITLE
fix(pipeline): restart jupyter-server oncreate

### DIFF
--- a/infra/lib/artefacts/cloudformation/sagemaker_notebook.yaml
+++ b/infra/lib/artefacts/cloudformation/sagemaker_notebook.yaml
@@ -198,7 +198,7 @@ Resources:
               echo "export S3_NAME=${SagemakerBucketName}" >>
               /etc/profile.d/jupyter-env.sh
 
-              # initctl restart jupyter-server --no-wait
+              service jupyter-server restart
       OnStart:
         - Content: !Base64 >
             #!/bin/bash


### PR DESCRIPTION
Restart jupyter-server oncreate of the sagemaker notebook so that environment variables set in the oncreate stage are available.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
