### PR TITLE
fix: downgrading default notebook platform

### DIFF
--- a/infra/lib/artefacts/cloudformation/sagemaker_notebook.yaml
+++ b/infra/lib/artefacts/cloudformation/sagemaker_notebook.yaml
@@ -239,6 +239,7 @@ Resources:
     Properties:
       InstanceType: !Ref SageMakeNotebookInstanceType
       DirectInternetAccess: Enabled
+      PlatformIdentifier: notebook-al2-v1
       RoleArn: !GetAtt 
         - NotebookIAMRole
         - Arn


### PR DESCRIPTION
Beginning of 2023 sagemaker stopped supporting the notebooks on al1 platform.

https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-al2.html

Now by default all notebooks created on sagemaker use the notebook-al2-v2 Platform. This broke our current notebook template where we stopped getting the environment variables in the notebook.

This fix downgrades the platform to notebook-al2-v1 platform to fix the problem.

Tested it with a pipeline I created and it worked.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
