### PR TITLE
feat: uploadAssetWorkflow stepfunction orchestration

### DIFF
--- a/backend/backend/handlers/workflows/createWorkflow.py
+++ b/backend/backend/handlers/workflows/createWorkflow.py
@@ -188,6 +188,12 @@ def create_step_function(pipelines, databaseId, workflowId):
             step = create_lambda_step(pipeline, input_s3_uri, output_s3_uri)
         else:
             step = create_sagemaker_step(databaseId, region, role, account_id, job_names, instance_type, i, pipeline, input_s3_uri, output_s3_uri)
+        step.add_retry(retry=stepfunctions.steps.Retry(
+            error_equals=["States.ALL"],
+            interval_seconds=5,
+            backoff_rate=2,
+            max_attempts=3
+        ))
         step.add_catch(catch_state_processing)
         steps.append(step)
 

--- a/backend/backend/models/assets.py
+++ b/backend/backend/models/assets.py
@@ -34,8 +34,8 @@ class ExecuteWorkflowModel(BaseModel):
 
 class UploadAssetWorkflowRequestModel(BaseModel):
     uploadAssetBody: UploadAssetModel
-    updateMetadataModel: UpdateMetadataModel
-    executeWorkflowModel: ExecuteWorkflowModel
+    updateMetadataBody: UpdateMetadataModel
+    executeWorkflowBody: ExecuteWorkflowModel
 
 
 class UploadAssetWorkflowResponseModel(BaseModel):
@@ -77,7 +77,7 @@ class UploadAssetStepFunctionRequest(BaseModel):
 
 class UploadAssetWorkflowStepFunctionInput(BaseModel):
     uploadAssetBody: UploadAssetStepFunctionRequest
-    updateAssetMetadataBody: UpdateAssetMetadataStepFunctionRequest
+    updateMetadataBody: UpdateAssetMetadataStepFunctionRequest
     executeWorkflowBody: List[ExecuteWorkflowStepFunctionRequest]
 
 
@@ -92,8 +92,8 @@ def GetUploadAssetWorkflowStepFunctionInput(
                 assetId=uploadAssetWorkflowRequestModel.uploadAssetBody.assetId,
     )
     metadataBody = UpdateAssetMetadataBody(
-                version=uploadAssetWorkflowRequestModel.updateMetadataModel.version,
-                metadata=uploadAssetWorkflowRequestModel.updateMetadataModel.metadata
+                version=uploadAssetWorkflowRequestModel.updateMetadataBody.version,
+                metadata=uploadAssetWorkflowRequestModel.updateMetadataBody.metadata
     )
     executeWorkflowBody = [ExecuteWorkflowStepFunctionRequest(
             pathParameters=ExecuteWorkflowPathParameters(
@@ -101,10 +101,10 @@ def GetUploadAssetWorkflowStepFunctionInput(
                 assetId=uploadAssetWorkflowRequestModel.uploadAssetBody.assetId,
                 workflowId=x
             )
-    ) for x in uploadAssetWorkflowRequestModel.executeWorkflowModel.workflowIds]
+    ) for x in uploadAssetWorkflowRequestModel.executeWorkflowBody.workflowIds]
     return UploadAssetWorkflowStepFunctionInput(
         uploadAssetBody=uploadAssetBody,
-        updateAssetMetadataBody=UpdateAssetMetadataStepFunctionRequest(
+        updateMetadataBody=UpdateAssetMetadataStepFunctionRequest(
             pathParameters=metadataPathParameters,
             body=metadataBody
         ),

--- a/backend/tests/functions/assets/upload_asset_workflow/test_lambda_handler.py
+++ b/backend/tests/functions/assets/upload_asset_workflow/test_lambda_handler.py
@@ -34,13 +34,13 @@ def sample_request():
                 Key='test_preview_key'
             )
         ),
-        updateMetadataModel=UpdateMetadataModel(
+        updateMetadataBody=UpdateMetadataModel(
             version="1",
             metadata={
                 'test': 'test'
             }
         ),
-        executeWorkflowModel=ExecuteWorkflowModel(
+        executeWorkflowBody=ExecuteWorkflowModel(
             workflowIds=[
                 'test1',
                 'test2',

--- a/backend/tests/functions/assets/upload_asset_workflow/test_request_handler.py
+++ b/backend/tests/functions/assets/upload_asset_workflow/test_request_handler.py
@@ -43,13 +43,13 @@ def sample_request():
                 Key='test_preview_key'
             )
         ),
-        updateMetadataModel=UpdateMetadataModel(
+        updateMetadataBody=UpdateMetadataModel(
             version="1",
             metadata={
                 'test': 'test'
             }
         ),
-        executeWorkflowModel=ExecuteWorkflowModel(
+        executeWorkflowBody=ExecuteWorkflowModel(
             workflowIds=[
                 'test1',
                 'test2',

--- a/backend/tests/models/assets/test_common.py
+++ b/backend/tests/models/assets/test_common.py
@@ -27,13 +27,13 @@ def sample_request():
                 Key='test_preview_key'
             )
         ),
-        updateMetadataModel=UpdateMetadataModel(
+        updateMetadataBody=UpdateMetadataModel(
             version="1",
             metadata={
                 'test': 'test'
             }
         ),
-        executeWorkflowModel=ExecuteWorkflowModel(
+        executeWorkflowBody=ExecuteWorkflowModel(
             workflowIds=[
                 'test1',
                 'test2',

--- a/backend/tests/models/assets/test_common.py
+++ b/backend/tests/models/assets/test_common.py
@@ -27,6 +27,7 @@ def sample_request():
                 Key='test_preview_key'
             )
         ),
+        copyFrom="test/src",
         updateMetadataBody=UpdateMetadataModel(
             version="1",
             metadata={
@@ -43,7 +44,37 @@ def sample_request():
     )
 
 
+@pytest.fixture()
+def only_required():
+    return UploadAssetWorkflowRequestModel(
+        uploadAssetBody=UploadAssetModel(
+            databaseId='1',
+            assetId='test',
+            bucket='test_bucket',
+            key='test_file',
+            assetType='step',
+            description='Testing',
+            isDistributable=False,
+            specifiedPipelines=[],
+            Comment='Testing',
+            previewLocation=AssetPreviewLocationModel(
+                Bucket='test_bucket',
+                Key='test_preview_key'
+            )
+        )
+    )
+
+
 def test_step_function_input_from_request(sample_request):
-    print("Testing")
     result = GetUploadAssetWorkflowStepFunctionInput(sample_request)
-    assert result is not None
+    assert result.copyObjectBody is not None
+    assert result.updateMetadataBody is not None
+    assert result.executeWorkflowBody is not None
+    assert result.uploadAssetBody is not None
+
+
+def test_step_function_input_required(only_required):
+    result = GetUploadAssetWorkflowStepFunctionInput(only_required)
+    assert result.updateMetadataBody is None
+    assert result.executeWorkflowBody is None
+    assert result.uploadAssetBody is not None

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -19,15 +19,20 @@ const region = process.env.AWS_REGION || app.node.tryGetContext("region") || "us
 const stackName = (process.env.STACK_NAME || app.node.tryGetContext("stack-name")) + "-" + region;
 const dockerDefaultPlatform = process.env.DOCKER_DEFAULT_PLATFORM ;
 const enableCdkNag = true; 
+const stagingBucket = process.env.STAGING_BUCKT || app.node.tryGetContext("staging-bucket")
 
 console.log('CDK_NAG_ENABLED 👉', enableCdkNag);
 console.log('STACK_NAME 👉', stackName);
 console.log('REGION 👉', region);
 console.log('DOCKER_DEFAULT_PLATFORM 👉', dockerDefaultPlatform);
+if(stagingBucket) {
+    console.log('STAGING_BUCKET 👉', stagingBucket)
+}
 
 if(enableCdkNag) {
     Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }))
 }
+
 
 //The web access firewall currently needs to be in us-east-1
 const cfWafStack = new CfWafStack(app, `vams-waf-${stackName || process.env.DEMO_LABEL || 'dev'}`, {
@@ -48,7 +53,8 @@ const vamsStack = new VAMS(app, `vams-${stackName || process.env.DEMO_LABEL || '
     },
     ssmWafArnParameterName: cfWafStack.ssmWafArnParameterName,
     ssmWafArnParameterRegion: cfWafStack.region,
-    ssmWafArn: cfWafStack.wafArn
+    ssmWafArn: cfWafStack.wafArn,
+    stagingBucket: stagingBucket
 });
 
 vamsStack.addDependency(cfWafStack);

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -19,7 +19,7 @@ const region = process.env.AWS_REGION || app.node.tryGetContext("region") || "us
 const stackName = (process.env.STACK_NAME || app.node.tryGetContext("stack-name")) + "-" + region;
 const dockerDefaultPlatform = process.env.DOCKER_DEFAULT_PLATFORM ;
 const enableCdkNag = true; 
-const stagingBucket = process.env.STAGING_BUCKT || app.node.tryGetContext("staging-bucket")
+const stagingBucket = process.env.STAGING_BUCKET || app.node.tryGetContext("staging-bucket")
 
 console.log('CDK_NAG_ENABLED 👉', enableCdkNag);
 console.log('STACK_NAME 👉', stackName);

--- a/infra/lib/api-builder.ts
+++ b/infra/lib/api-builder.ts
@@ -353,9 +353,15 @@ export function apiBuilder(
     const uploadAssetWorkflowStateMachine = buildUploadAssetWorkflow(scope, 
         uploadAssetFunction, 
         metadataCrudFunctions[2],
-        runWorkflowFunction
+        runWorkflowFunction, 
+        storageResources.s3.assetBucket,
+        storageResources.s3.stagingBucket
     );
     uploadAssetFunction.grantInvoke(uploadAssetWorkflowStateMachine);
+    storageResources.s3.assetBucket.grantReadWrite(uploadAssetWorkflowStateMachine)
+    if(storageResources.s3.stagingBucket) {
+        storageResources.s3.stagingBucket.grantRead(uploadAssetWorkflowStateMachine)
+    }
 
     const uploadAssetWorkflowFunction = buildUploadAssetWorkflowFunction(
         scope,

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -22,6 +22,7 @@ interface EnvProps {
     ssmWafArnParameterName: string;
     ssmWafArnParameterRegion: string;
     ssmWafArn: string;
+    stagingBucket?: string;
 }
 
 export class VAMS extends cdk.Stack {
@@ -36,8 +37,8 @@ export class VAMS extends cdk.Stack {
         });
 
         const webAppBuildPath = "../web/build";
-
-        const storageResources = storageResourcesBuilder(this);
+        
+        const storageResources = storageResourcesBuilder(this, props.stagingBucket);
         const trail = new cloudTrail.Trail(this, 'CloudTrail-VAMS', {
             isMultiRegionTrail: false,
             bucket: storageResources.s3.accessLogsBucket, 

--- a/infra/lib/storage-builder.ts
+++ b/infra/lib/storage-builder.ts
@@ -18,6 +18,7 @@ export interface storageResources {
         artefactsBucket: s3.Bucket;
         accessLogsBucket: s3.Bucket;
         sagemakerBucket: s3.Bucket;
+        stagingBucket?: s3.IBucket;
     };
     dynamo: {
         assetStorageTable: dynamodb.Table;
@@ -29,7 +30,7 @@ export interface storageResources {
         metadataStorageTable: dynamodb.Table;
     };
 }
-export function storageResourcesBuilder(scope: Construct): storageResources {
+export function storageResourcesBuilder(scope: Construct, staging_bucket?: string): storageResources {
     const accessLogsBucket = new s3.Bucket(scope, "AccessLogsBucket", {
         encryption: s3.BucketEncryption.S3_MANAGED,
         serverAccessLogsPrefix: "access-log-bucket-logs/",
@@ -78,6 +79,10 @@ export function storageResourcesBuilder(scope: Construct): storageResources {
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
     requireTLSAddToResourcePolicy(sagemakerBucket);
+
+    let stagingBucket = undefined
+    if(staging_bucket)
+        stagingBucket = s3.Bucket.fromBucketName(scope, "Staging Bucket", staging_bucket)
 
     new s3deployment.BucketDeployment(scope, "DeployArtefacts", {
         sources: [s3deployment.Source.asset("./lib/artefacts")],
@@ -195,6 +200,7 @@ export function storageResourcesBuilder(scope: Construct): storageResources {
             artefactsBucket: artefactsBucket,
             accessLogsBucket: accessLogsBucket,
             sagemakerBucket: sagemakerBucket,
+            stagingBucket: stagingBucket,
         },
         dynamo: {
             assetStorageTable: assetStorageTable,

--- a/infra/lib/uploadAssetWorkflowBuilder.ts
+++ b/infra/lib/uploadAssetWorkflowBuilder.ts
@@ -2,46 +2,94 @@ import { Construct } from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
-import * as logs from 'aws-cdk-lib/aws-logs';
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as s3 from "aws-cdk-lib/aws-s3";
 import { Duration } from "aws-cdk-lib";
-import { State, TaskInput } from "aws-cdk-lib/aws-stepfunctions";
+import { JsonPath, State, TaskInput } from "aws-cdk-lib/aws-stepfunctions";
 
 export function buildUploadAssetWorkflow(
     scope: Construct,
-    uploadAssetFunction: lambda.Function, 
+    uploadAssetFunction: lambda.Function,
     updateMetadataFunction: lambda.Function,
     executeWorkflowFunction: lambda.Function,
+    assetBucket: s3.Bucket,
+    stagingBucket?: s3.IBucket
 ): sfn.StateMachine {
     const callUploadAssetLambdaTask = new tasks.LambdaInvoke(scope, "Upload Asset Task", {
         lambdaFunction: uploadAssetFunction,
         payload: TaskInput.fromJsonPathAt("$.uploadAssetBody"),
         resultPath: "$.uploadAssetResult",
-        outputPath: "$"
+        outputPath: "$",
     });
+
     const callUpdateMetadataTask = new tasks.LambdaInvoke(scope, "Update Metadata Task", {
         lambdaFunction: updateMetadataFunction,
         payload: TaskInput.fromJsonPathAt("$.updateMetadataBody"),
         resultPath: "$.updateMetadataResult",
-        outputPath: "$"
+        outputPath: "$",
     });
-    const map = new sfn.Map(scope, 'Map State', {
+    const map = new sfn.Map(scope, "Map State", {
         maxConcurrency: 1,
-        itemsPath: sfn.JsonPath.stringAt('$.executeWorkflowBody'),
-      });
+        itemsPath: sfn.JsonPath.stringAt("$.executeWorkflowBody"),
+    });
     const callExecuteWorkflowTask = new tasks.LambdaInvoke(scope, "Call Execute Workflows Task", {
-        lambdaFunction: executeWorkflowFunction
+        lambdaFunction: executeWorkflowFunction,
     });
     map.iterator(callExecuteWorkflowTask);
 
-    const logGroup = new logs.LogGroup(scope, 'UploadAssetWorkflowLogs');
-    const definition = callUploadAssetLambdaTask.next(callUpdateMetadataTask).next(map);
+    const pass = new sfn.Pass(scope, "No metadata included");
+    const updateMetadataChoice = new sfn.Choice(scope, "Is metadata included?")
+        .when(sfn.Condition.isNotNull("$.updateMetadataBody"), callUpdateMetadataTask)
+        .when(sfn.Condition.isNull("$.updateMetadataBody"), pass)
+        .afterwards();
+
+    const passE = new sfn.Pass(scope, "No workflows included");
+    const callExecuteWorkflowChoice = new sfn.Choice(scope, "Are workflows included?")
+        .when(sfn.Condition.isNotNull("$.executeWorkflowBody"), map)
+        .when(sfn.Condition.isNull("$.executeWorkflowBody"), passE)
+        .afterwards();
+
+    let definition;
+    if (stagingBucket) {
+        const copyObjectTask = new tasks.CallAwsService(scope, "S3 Copy Object", {
+            service: "s3",
+            action: "copyObject",
+            iamResources: [
+                stagingBucket.arnForObjects("*")
+            ],
+            inputPath: "$.copyObjectBody",
+            parameters: {
+                Bucket: JsonPath.stringAt("$.bucket"),
+                Key: JsonPath.stringAt("$.key"),
+                CopySource: JsonPath.stringAt("$.copySource"),
+            },
+            resultPath: JsonPath.DISCARD,
+            outputPath: "$",
+        });
+        const passCopy = new sfn.Pass(scope, "Object not provided");
+        const copyObjectChoice = new sfn.Choice(scope, "Is Object included?")
+            .when(sfn.Condition.isNotNull("$.copyObjectBody"), copyObjectTask)
+            .when(sfn.Condition.isNull("$.copyObjectBody"), passCopy)
+            .afterwards();
+
+        definition = copyObjectChoice
+            .next(callUploadAssetLambdaTask)
+            .next(updateMetadataChoice)
+            .next(callExecuteWorkflowChoice);
+    } else {
+        definition = callUploadAssetLambdaTask
+            .next(updateMetadataChoice)
+            .next(callExecuteWorkflowChoice);
+    }
+
+    const logGroup = new logs.LogGroup(scope, "UploadAssetWorkflowLogs");
     return new sfn.StateMachine(scope, "UploadAssetWorkflow", {
         definition: definition,
         timeout: Duration.minutes(10),
         logs: {
             level: sfn.LogLevel.ALL,
-            destination: logGroup
+            destination: logGroup,
         },
-        tracingEnabled: true //This was pointed out by CDK-Nag
+        tracingEnabled: true, //This was pointed out by CDK-Nag
     });
 }

--- a/infra/lib/uploadAssetWorkflowBuilder.ts
+++ b/infra/lib/uploadAssetWorkflowBuilder.ts
@@ -15,10 +15,14 @@ export function buildUploadAssetWorkflow(
     const callUploadAssetLambdaTask = new tasks.LambdaInvoke(scope, "Upload Asset Task", {
         lambdaFunction: uploadAssetFunction,
         payload: TaskInput.fromJsonPathAt("$.uploadAssetBody"),
+        resultPath: "$.uploadAssetResult",
+        outputPath: "$"
     });
     const callUpdateMetadataTask = new tasks.LambdaInvoke(scope, "Update Metadata Task", {
         lambdaFunction: updateMetadataFunction,
         payload: TaskInput.fromJsonPathAt("$.updateMetadataBody"),
+        resultPath: "$.updateMetadataResult",
+        outputPath: "$"
     });
     const map = new sfn.Map(scope, 'Map State', {
         maxConcurrency: 1,


### PR DESCRIPTION
*Description of changes:*

This commit includes all the backend changes necessary for supporting the uploadAssetWorkflow feature. This feature allows user to ingest asset, upload metadata and call workflows on the asset using a single API call.
    
  1. Changes include in the backed to
  - Copy asset from existing s3 bucket in same region and same account
  - Ingest asset index data
  - Ingest asset metadata
  - Invoke workflows after ingestion
  2. All of this is orchestrated using stepfunctions
  3. Included a new env variable during deployment time called staging_bucket which can be used if use
r already has assets in a bucket and merely wants copy them over to vams bucket.
  4. Included a retry logic on sagemaker processing job step as it was failing when I submitted two jo
bs simultaneously with this workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
