### PR TITLE
chore: update to list_objects_v2

### DIFF
--- a/backend/backend/handlers/assets/uploadAllAssets.py
+++ b/backend/backend/handlers/assets/uploadAllAssets.py
@@ -82,7 +82,14 @@ def lambda_handler(event, context):
     print(bucket_name, prefix)
 
     s3 = boto3.client("s3")
-    all_outputs = s3.list_objects(Bucket=bucket_name, Prefix=prefix) 
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.list_objects_v2
+    all_outputs = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+    if 'IsTruncated' in all_outputs and all_outputs['IsTruncated']:
+        print(
+            "WARN: s3 object listing exceeds 1,000 objects,",
+            "this is unexpected for this operation with the bucket and prefix",
+            bucket_name, prefix
+        )
     print(all_outputs)
     assets = []
     if 'Contents' in all_outputs:


### PR DESCRIPTION
*Description of changes:*

This addresses two Amazon Code Guru items:

- The API method `list_objects` returns paginated results instead of all results. Consider using the pagination API or checking one of the following keys in the response to verify that all results were returned: `IsTruncated`, `Marker`, `NextMarker`, `NextToken`. [Learn more](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html)
- This code uses an outdated API. [list_objects_v2 is the revised List Objects API, and we recommend you use this revised API for new application developments](https://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
