### PR TITLE
Adjusted default permission for S3 buckets to match latest security changes

### DIFF
--- a/infra/lib/constructs/cloudfront-s3-website-construct.ts
+++ b/infra/lib/constructs/cloudfront-s3-website-construct.ts
@@ -63,6 +63,7 @@ export class CloudFrontS3WebSiteConstruct extends Construct {
             serverAccessLogsPrefix: "web-app-access-log-bucket-logs/",
             versioned: true,
             blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
         });
         requireTLSAddToResourcePolicy(accessLogsBucket);
 
@@ -83,6 +84,7 @@ export class CloudFrontS3WebSiteConstruct extends Construct {
             serverAccessLogsBucket: accessLogsBucket,
             serverAccessLogsPrefix: "web-app-access-log-bucket-logs/",
             blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
         });
         requireTLSAddToResourcePolicy(siteBucket);
 

--- a/infra/lib/storage-builder.ts
+++ b/infra/lib/storage-builder.ts
@@ -53,6 +53,7 @@ export function storageResourcesBuilder(
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
         versioned: true,
         encryption: s3.BucketEncryption.S3_MANAGED,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
     };
 
     const accessLogsBucket = new s3.Bucket(scope, "AccessLogsBucket", {


### PR DESCRIPTION
*Description of changes:*

Adjusted default permission for S3 buckets to match latest security changes, as outlined here: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

Tested locally, without this change it was failing to setup when I ran npm run deploy.dev, with this change it succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
