### PR TITLE
fix: renaming userpool causes failures in existing stack

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -70,7 +70,7 @@ export class VAMS extends cdk.Stack {
 
         const cognitoResources = new CognitoWebNativeConstruct(this, "Cognito", cognitoProps);
 
-        const adminUser = new cognito.CfnUserPoolUser(this, "AdminUser", {
+        const congitoUser = new cognito.CfnUserPoolUser(this, "AdminUser", {
             username: providedAdminEmailAddress,
             userPoolId: cognitoResources.userPoolId,
             desiredDeliveryMediums: ["EMAIL"],


### PR DESCRIPTION
The existing userPool adminUserPool was renamed from the original congitoUserPool and caused failures when I was redeploying to an account where VAMS was already deployed.

CDK thinks that you are deleting the existing userpool and CloudFormation blocks stack from updating with error
```
Existing schema attributes cannot be modified or deleted. (Service: AWSCognitoIdentityProvider; Status Code: 400; Error Code: InvalidParameterException; Request ID: null; Proxy: null)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
