### PR TITLE
feat: Support long running pipelines with Step Functions' wait for callback feature.

### DIFF
--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -188,7 +188,7 @@ This new `determine_vams_roles` can replace the existing function in `pretokenge
 
 # Implementing pipelines outside of Lambda or Sagemeker
 
-To process an asset through VAMS using an external system or when a job can take longer than the Lambda timeout of 15 minutes, it is recommended that you use the _Wait for a Callback with the Task Token_ feature so that the Pipeline Lambda can initiate your job and then exit instead of waiting for the work to complete before it also finishes. This reduces your Lambda costs and helps you avoid failed jobs that fail simply because they take longer than the timeout to complete. 
+To process an asset through VAMS using an external system or when a job can take longer than the Lambda timeout of 15 minutes, it is recommended that you use the _Wait for a Callback with the Task Token_ feature so that the Pipeline Lambda can initiate your job and then exit instead of waiting for the work to complete before it also finishes. This reduces your Lambda costs and helps you avoid failed jobs that fail simply because they take longer than the timeout to complete.
 
 To use _Wait for a call back with the Task Token_, enable the option to use Task Tokens on the create pipeline screen. When using this option, you must explicitly make a callback to the Step Functions API with the Task Token in the event passed to your Lambda function. The Task Token is provided in the event with the key `TaskToken`. You can see this using the Step Functions execution viewer under the Input tab for an execution with the call back enabled. Pass the `TaskToken` to the system that can notify the Step Functions API that the work is complete with the `SendTaskSuccess` message.
 
@@ -209,9 +209,9 @@ response = client.send_task_success(
 
 For other platforms, see the SDK documentation.
 
-For task failures, see the adjacent api calls for `SendTaskFailure`. 
+For task failures, see the adjacent api calls for `SendTaskFailure`.
 
-Two additional settings enable your job to end with a timeout error by defining a task timeout. This can reduce your time to detect a problem with your task. By default, the timeout is over a year when working with task tokens. To set a timeout, specify a Task Timeout on the create pipeline screen. 
+Two additional settings enable your job to end with a timeout error by defining a task timeout. This can reduce your time to detect a problem with your task. By default, the timeout is over a year when working with task tokens. To set a timeout, specify a Task Timeout on the create pipeline screen.
 
 If you would like your job check in to show that it is still running and fail the step if it does not check in within some amount of time less than the task timeout, define the Task Heartbeat Timeout on the create pipeline screen also. If more time than the specified seconds elapses between heartbeats from the task, this state fails with a States.Timeout error name.
 

--- a/backend/backend/handlers/pipelines/createPipeline.py
+++ b/backend/backend/handlers/pipelines/createPipeline.py
@@ -84,9 +84,17 @@ def upload_Pipeline(body):
         'description': body['description'],
         'dateCreated': json.dumps(dtNow),
         'pipelineType':body['pipelineType'],
+        'waitForCallback': body['waitForCallback'],
         'userProvidedResource': json.dumps(userResource),
         'enabled':False #Not doing anything with this yet
     }
+
+    if 'taskTimeout' in body:
+        item['taskTimeout'] = body['taskTimeout']
+
+    if 'taskHeartbeatTimeout' in body:
+        item['taskHeartbeatTimeout'] = body['taskHeartbeatTimeout']
+
     table.put_item(
         Item=item,
         ConditionExpression='attribute_not_exists(databaseId) and attribute_not_exists(pipelineId)'

--- a/web/src/components/createupdate/CreateUpdateElement.js
+++ b/web/src/components/createupdate/CreateUpdateElement.js
@@ -269,8 +269,9 @@ export default function CreateUpdateElement(props) {
                             //find the form field that isn't toggled based on pipeline type, then clear it.
                             const optionalFieldHidden =
                                 appearsWhen &&
-                                formValues[appearsWhen[0]] &&
-                                appearsWhen[1] !== formValues[appearsWhen[0]]["label"];
+                                ! ( formValues[appearsWhen[0]] &&
+                                appearsWhen[1] === formValues[appearsWhen[0]]["label"]);
+
                             if (formValues[id] && optionalFieldHidden) {
                                 console.log(id + ": " + formValues[id]);
                                 formValues[id] = "";

--- a/web/src/components/createupdate/CreateUpdateElement.js
+++ b/web/src/components/createupdate/CreateUpdateElement.js
@@ -269,8 +269,10 @@ export default function CreateUpdateElement(props) {
                             //find the form field that isn't toggled based on pipeline type, then clear it.
                             const optionalFieldHidden =
                                 appearsWhen &&
-                                ! ( formValues[appearsWhen[0]] &&
-                                appearsWhen[1] === formValues[appearsWhen[0]]["label"]);
+                                !(
+                                    formValues[appearsWhen[0]] &&
+                                    appearsWhen[1] === formValues[appearsWhen[0]]["label"]
+                                );
 
                             if (formValues[id] && optionalFieldHidden) {
                                 console.log(id + ": " + formValues[id]);

--- a/web/src/components/createupdate/CreateUpdateWorkflow.js
+++ b/web/src/components/createupdate/CreateUpdateWorkflow.js
@@ -72,6 +72,9 @@ export default function CreateUpdateWorkflow(props) {
                         value: item.name,
                         type: item.pipelineType,
                         outputType: item.outputType,
+                        waitForCallback: item.waitForCallback,
+                        taskTimeout: item.taskTimeout,
+                        taskHeartbeatTimeout: item.taskHeartbeatTimeout,
                         userProvidedResource: item.userProvidedResource,
                     };
                 });
@@ -137,6 +140,9 @@ export default function CreateUpdateWorkflow(props) {
                     name: item.value,
                     pipelineType: item.type,
                     outputType: item.outputType,
+                    waitForCallback: item.waitForCallback,
+                    taskTimeout: item.taskTimeout,
+                    taskHeartbeatTimeout: item.taskHeartbeatTimeout,
                     userProvidedResource: item.userProvidedResource,
                 };
             });

--- a/web/src/components/createupdate/entity-types/PipelineEntity.js
+++ b/web/src/components/createupdate/entity-types/PipelineEntity.js
@@ -11,6 +11,7 @@ export default function PipelineEntity(props) {
         databaseId,
         description,
         pipelineType,
+        waitForCallback,
         externalContainerUri,
         externalLambdaName,
         assetType,
@@ -20,6 +21,7 @@ export default function PipelineEntity(props) {
     this.databaseId = databaseId;
     this.description = description;
     this.pipelineType = pipelineType;
+    this.waitForCallback = waitForCallback;
     this.externalContainerUri = externalContainerUri;
     this.externalLambdaName = externalLambdaName;
     this.assetType = assetType;
@@ -31,6 +33,7 @@ PipelineEntity.propTypes = {
     databaseId: EntityPropTypes.ENTITY_ID,
     description: EntityPropTypes.STRING_256,
     pipelineType: EntityPropTypes.STRING_32,
+    waitForCallback: EntityPropTypes.BOOLEAN,
     assetType: EntityPropTypes.FILE_TYPE,
     outputType: EntityPropTypes.FILE_TYPE,
     containerUri: EntityPropTypes.CONTAINER_URI,

--- a/web/src/components/createupdate/form-definitions/PipelineFormDefinition.js
+++ b/web/src/components/createupdate/form-definitions/PipelineFormDefinition.js
@@ -82,6 +82,65 @@ export const PipelineFormDefinition = new FormDefinition({
             required: true,
         }),
         new ControlDefinition({
+            label: "Wait for a Callback with the Task Token",
+            id: "waitForCallback",
+            constraintText:
+                "Applies to Lambda pipelines only. More information available in the Step Functions documentation https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html.",
+            elementDefinition: new ElementDefinition({
+                formElement: Select,
+                elementProps: {
+                    "data-testid": "waitForCallback-select",
+                },
+            }),
+            options: [
+                {
+                    label: "Yes",
+                    value: "Enabled",
+                },
+                {
+                    label: "No",
+                    value: "Disabled",
+                },
+            ],
+            appearsWhen: ["pipelineType", "Lambda"],
+            defaultOption: {
+                label: "No",
+                value: "Disabled",
+            },
+        }),
+        new ControlDefinition({
+            label: "Task Timeout",
+            id: "taskTimeout",
+            constraintText:
+                "If the task runs longer than the specified seconds, this state fails with a States.Timeout error name. Must be a positive, non-zero integer.",
+            elementDefinition: new ElementDefinition({
+                formElement: Input,
+                elementProps: {
+                    autoFocus: false,
+                    type: "number",
+                    inputMode: "numeric",
+                    placeholder: "99999999",
+                },
+            }),
+            appearsWhen: ["waitForCallback", "Yes"],
+        }),
+        new ControlDefinition({
+            label: "Task Heartbeat Timeout",
+            id: "taskHeartbeatTimeout",
+            constraintText:
+                "If more time than the specified seconds elapses between heartbeats from the task, this state fails with a States.Timeout error name. Must be a positive, non-zero integer less than the number of seconds specified in the TimeoutSeconds field.",
+            elementDefinition: new ElementDefinition({
+                formElement: Input,
+                elementProps: {
+                    autoFocus: false,
+                    type: "number",
+                    inputMode: "numeric",
+                    placeholder: "99999999",
+                },
+            }),
+            appearsWhen: ["waitForCallback", "Yes"],
+        }),
+        new ControlDefinition({
             label: "Container Uri (Optional)",
             id: "containerUri",
             constraintText:

--- a/web/src/components/selectors/WorkflowPipelineSelector.js
+++ b/web/src/components/selectors/WorkflowPipelineSelector.js
@@ -63,6 +63,9 @@ const WorkflowPipelineSelector = (props) => {
                     value: item.pipelineId,
                     type: item.pipelineType,
                     outputType: item.outputType,
+                    waitForCallback: item.waitForCallback,
+                    taskTimeout: item.taskTimeout,
+                    taskHeartbeatTimeout: item.taskHeartbeatTimeout,
                     userProvidedResource: item.userProvidedResource,
                     tags: [
                         `input:${item.assetType}`,


### PR DESCRIPTION
*Description of changes:*

This change enables Pipeline creators to run jobs that take longer than the 15 minute Lambda function timeout by enabling use of Step Functions Task Tokens with VAMS Workflows and Pipelines. Before this change VAMS could only run a Lambda function or Sagemaker Job. Now, a Lambda function can spawn any workload and pass a "Task Token" so that the work can be marked complete in a VAMS Workflow state machine from any authorized compute resource rather than when the Lambda invoked by Step Functions completes. See updated DeveloperGuide.md for more info. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
