### PR TITLE
fix: cdk nag suppressions for python 3.9 and nodejs14.x

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -199,7 +199,9 @@ export class VAMS extends cdk.Stack {
         this.node.findAll().forEach((item) => {
             if (item instanceof cdk.aws_lambda.Function) {
                 const fn = item as cdk.aws_lambda.Function;
-                if (fn.runtime.name == "python3.9") {
+                // python3.9 suppressed for CDK Bucket Deployment
+                // nodejs14.x suppressed for use of custom resource to deploy saml in CustomCognitoConfigConstruct
+                if (fn.runtime.name === "python3.9" || fn.runtime.name === "nodejs14.x") {
                     NagSuppressions.addResourceSuppressions(fn, [
                         {
                             id: "AwsSolutions-L1",


### PR DESCRIPTION
*Description of changes:*

This addresses suppressions needed for python 3.9 and nodejs 14.x The last PR changing suppressions should not have removed the nodejs suppression. This nodejs suppression is needed when SAML is enabled and we make use of custom resources to configure Cognito which currently uses an outdated nodejs lambda. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
