### PR TITLE
feat: hiding sign up

### DIFF
--- a/infra/lib/constructs/cognito-web-native-construct.ts
+++ b/infra/lib/constructs/cognito-web-native-construct.ts
@@ -71,7 +71,7 @@ export class CognitoWebNativeConstruct extends Construct {
         );
 
         const userPool = new cognito.UserPool(this, "UserPool", {
-            selfSignUpEnabled: true,
+            selfSignUpEnabled: false,
             autoVerify: { email: true },
             userVerification: {
                 emailSubject: "Verify your email the app!",

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -55,7 +55,7 @@ function App() {
     }, [navigationOpen]);
 
     return (
-        <Authenticator components={components} loginMechanisms={["email"]}>
+        <Authenticator components={components} loginMechanisms={["email"]} hideSignUp={true}>
             {({ signOut, user }) => {
                 console.info("user", user);
                 const menuText =

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -205,7 +205,7 @@
   resolved "https://registry.yarnpkg.com/@aws-amplify/rtn-push-notification/-/rtn-push-notification-1.1.1.tgz#c2203600fe971f7dc1b3b38be58f1804a45afcd4"
   integrity sha512-uYPyiNeK2r2g82U6ayluNrKA2z5280mlW9razEul94i/2XPt9LAXhIb1XnCtxGzxANMHd+FH9V7D7RAGK99pTQ==
 
-"@aws-amplify/storage@5.6.3", "@aws-amplify/storage@^5.4.0":
+"@aws-amplify/storage@5.6.3":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/@aws-amplify/storage/-/storage-5.6.3.tgz#83349f49341e58cc3e4cd07b747900aea8073c33"
   integrity sha512-Yu7OwCIgUmVWNtsxOugbiBXnveP1ZnR4IswBJMMhPywPLolWqDdD6Kllm8vDMAb/xRD+TrbMgXaYBL1d7sFGww==
@@ -7910,7 +7910,7 @@ aws-amplify-react@^5.1.9:
     qrcode.react "^0.8.0"
     regenerator-runtime "^0.11.1"
 
-aws-amplify@^5.2.4:
+aws-amplify@^5.2.7:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/aws-amplify/-/aws-amplify-5.3.3.tgz#e6a75c7b7e11d2658f9bef33e78744f040acfd2f"
   integrity sha512-fTRJTcQrZ+CXm3XkkmVavflqx6eWSOmbIJc/cq06lZ6I/12B+rc+hNka6cLzAeqi1VL5Gf+EdVQFq1X7zUkSnw==


### PR DESCRIPTION
Since VAMS website is deployed on cloudfront, from security perspective it makes sense to hide signup from untrusted source.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
