### PR TITLE
fix: download asset only if they are marked as distributatble

### DIFF
--- a/web/src/components/single/AssetVisualizer.tsx
+++ b/web/src/components/single/AssetVisualizer.tsx
@@ -70,6 +70,7 @@ function AssetVisualizer(props: AssetVisualizerPropTypes) {
                             assetId={props.asset?.assetId}
                             databaseId={props.asset?.databaseId}
                             assetName={props.asset?.assetName}
+                            isDistributable={props.asset?.isDistributable}
                         />
                     )}
                 </div>

--- a/web/src/components/single/ViewAsset.js
+++ b/web/src/components/single/ViewAsset.js
@@ -409,6 +409,9 @@ export default function ViewAsset() {
                                                                 assetId={asset?.assetId}
                                                                 databaseId={asset?.databaseId}
                                                                 assetName={asset?.assetName}
+                                                                isDistributable={
+                                                                    asset?.isDistributable
+                                                                }
                                                             />
                                                         )}
                                                     </div>

--- a/web/src/components/viewers/FolderActionViewer.tsx
+++ b/web/src/components/viewers/FolderActionViewer.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from "react-router";
 export class FolderActionProps {
     databaseId!: string;
     assetId!: string;
+    isDistributable!: boolean;
     name!: string;
     urlKey!: string;
     isDirectory!: boolean;
@@ -43,7 +44,7 @@ export default function FolderActionViewer({ name, urlKey, ...props }: FolderAct
                             Selected {props.isDirectory ? "directory" : "file"} : {name}
                         </p>
 
-                        {!props.isDirectory && (
+                        {!props.isDirectory && props.isDistributable && (
                             <>
                                 <ColumnLayout columns={4}>
                                     <Button
@@ -70,14 +71,6 @@ export default function FolderActionViewer({ name, urlKey, ...props }: FolderAct
                             <Button variant={"primary"} onClick={() => navigateToAssetFilePage()}>
                                 View {props.isDirectory ? "directory" : "file"}
                             </Button>
-                            {props.isDirectory && (
-                                <>
-                                    <ColumnLayout columns={4}>
-                                        <Button> Add a Folder </Button>
-                                        <Button> Add a File </Button>
-                                    </ColumnLayout>
-                                </>
-                            )}
                         </p>
                     </>
                 )}

--- a/web/src/components/viewers/FolderViewer.tsx
+++ b/web/src/components/viewers/FolderViewer.tsx
@@ -11,6 +11,7 @@ class FolderViewerProps {
     databaseId!: string;
     assetId!: string;
     assetName!: string;
+    isDistributable!: boolean;
 }
 
 class AssetFileList {
@@ -18,13 +19,19 @@ class AssetFileList {
     relativePath!: string;
 }
 
-export default function FolderViewer({ databaseId, assetId, assetName }: FolderViewerProps) {
+export default function FolderViewer({
+    databaseId,
+    assetId,
+    assetName,
+    isDistributable,
+}: FolderViewerProps) {
     const [folderActionProps, setFolderActionProps] = useState<FolderActionProps>({
         databaseId,
         assetId,
         name: "",
         urlKey: "",
         isDirectory: true,
+        isDistributable: isDistributable,
     });
 
     const [treeState, setTreeState] = useState<NodeData>({
@@ -145,6 +152,7 @@ export default function FolderViewer({ databaseId, assetId, assetName }: FolderV
                         name={folderActionProps.name}
                         urlKey={folderActionProps.urlKey}
                         isDirectory={folderActionProps.isDirectory}
+                        isDistributable={folderActionProps.isDistributable}
                     />
                 </div>
             </ColumnLayout>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In a previous commit for folder upload I forgot to consider this flag property. Allowing others to download the asset only when its marked as distributable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
