### PR TITLE
Improvements to opensearch data indexing

### DIFF
--- a/backend/backend/handlers/metadata/read.py
+++ b/backend/backend/handlers/metadata/read.py
@@ -1,13 +1,11 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import sys
 import json
-from decimal import Decimal
 import traceback
 
-from backend.handlers.metadata import logger, mask_sensitive_data, build_response, table, validate_event, ValidationError
+from backend.handlers.metadata import logger, mask_sensitive_data, \
+    build_response, table, validate_event, ValidationError
 from backend.handlers.auth import get_database_set, request_to_claims
 
 
@@ -18,9 +16,10 @@ def generate_prefixes(path):
         prefix = '/'.join(parts[:i]) + '/'
         prefixes.insert(0, prefix)
 
-    if(not path.endswith('/')):
+    if (not path.endswith('/')):
         prefixes.insert(0, path)
     return prefixes
+
 
 def get_metadata_with_prefix(databaseId, assetId, prefix):
     result = {}
@@ -38,10 +37,12 @@ def get_metadata_with_prefix(databaseId, assetId, prefix):
             asset_metadata = get_metadata(databaseId, assetId)
             result = asset_metadata | result
             return result
-        except ValidationError as ex:
+        except ValidationError:
             return result
     else:
         return get_metadata(databaseId, assetId)
+
+
 def get_metadata(databaseId, assetId):
     resp = table.get_item(
         Key={
@@ -61,23 +62,35 @@ def lambda_handler(event, context):
         databaseId = event['pathParameters']['databaseId']
         assetId = event['pathParameters']['assetId']
         prefix = None
-        if ('queryStringParameters' in event and 'prefix' in event['queryStringParameters']):
-            prefix = event['queryStringParameters'] and event['queryStringParameters']['prefix']
+        if ('queryStringParameters' in event
+                and 'prefix' in event['queryStringParameters']):
+            prefix = (event['queryStringParameters']
+                      and event['queryStringParameters']['prefix'])
 
         claims_and_roles = request_to_claims(event)
         databases = get_database_set(claims_and_roles['tokens'])
-        if databaseId in databases or "super-admin" in claims_and_roles['roles']:
+        if (databaseId in databases
+                or "super-admin" in claims_and_roles['roles']):
+
+            metadata = get_metadata_with_prefix(databaseId, assetId, prefix)
+
+            # remove private keys that start with underscores
+            for key in list(metadata.keys()):
+                if key.startswith("_"):
+                    del metadata[key]
+
             return build_response(200, json.dumps({
                 "version": "1",
-                "metadata": get_metadata_with_prefix(databaseId, assetId, prefix)
+                "metadata": metadata,
             }))
         else:
-            print("raising 403 databaseId not in claims and roles?", databaseId, claims_and_roles, databases)
+            print("raising 403 databaseId not in claims and roles?",
+                  databaseId, claims_and_roles, databases)
             raise ValidationError(403, "Not Authorized")
 
     except ValidationError as ex:
         logger.info(traceback.format_exc())
         return build_response(ex.code, json.dumps(ex.resp))
-    except Exception as ex:
+    except Exception:
         logger.error(traceback.format_exc())
         return build_response(500, "Server Error")

--- a/backend/tests/handlers/indexing/test_streams.py
+++ b/backend/tests/handlers/indexing/test_streams.py
@@ -65,7 +65,7 @@ example_event = {
                 "SizeBytes": 926,
                 "StreamViewType": "NEW_IMAGE"
             },
-            "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109" # noqa E501
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable.../stream/2023-06-21T01:08:09.109" # noqa E501
         }
     ]
 }
@@ -90,7 +90,7 @@ example_event_delete = {
         "SizeBytes": 23,
         "StreamViewType": "NEW_IMAGE"
     },
-    "eventSourceARN": "arn:aws:dynamodb:us-east-1:123123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109" # noqa E501
+    "eventSourceARN": "arn:aws:dynamodb:us-east-1:123123123:table/vams-dev-us-east-1-MetadataStorageTable.../stream/2023-06-21T01:08:09.109" # noqa E501
 }
 
 example_event_delete_records = {
@@ -115,7 +115,7 @@ example_event_delete_records = {
                 "SizeBytes": 23,
                 "StreamViewType": "NEW_IMAGE"
             },
-            "eventSourceARN": "arn:aws:dynamodb:us-east-1::table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109" # noqa E501
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1::table/vams-dev-us-east-1-MetadataStorageTable.../stream/2023-06-21T01:08:09.109" # noqa E501
         }
     ]
 }

--- a/backend/tests/handlers/indexing/test_streams_fixtures/example_event.json
+++ b/backend/tests/handlers/indexing/test_streams_fixtures/example_event.json
@@ -1,0 +1,36 @@
+{
+    "Records": [
+        {
+            "eventID": "f33f76a1c323cd5c40ba06d06c9f84f7",
+            "eventName": "MODIFY",
+            "eventVersion": "1.1",
+            "eventSource": "aws:dynamodb",
+            "awsRegion": "us-east-1",
+            "dynamodb": {
+                "ApproximateCreationDateTime": 1687310394.0,
+                "Keys": {
+                    "assetId": { "S": "x68c65799-7312-4476-882b-411a609ba670" },
+                    "databaseId": { "S": "asdf" }
+                },
+                "NewImage": {
+                    "Boolean Example": { "S": "true" },
+                    "Example String Name": { "S": "example string value" },
+                    "Example Number": { "N": "123" },
+                    "assetId": { "S": "x68c65799-7312-4476-882b-411a609ba670" },
+                    "Business Line": { "S": "Musical Instruments" },
+                    "Site ID": { "S": "6" },
+                    "Date Example": { "S": "2023-06-28" },
+                    "location": {
+                        "S": "{\"loc\":[\"-91.2091897\",\"30.5611007\"],\"zoom\":\"14\",\"polygons\":{\"type\":\"FeatureCollection\",\"features\":[{\"id\":\"a5d440f5cb30db2b50ade518bac047e2\",\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"coordinates\":[[[-91.2056920994444,30.565357807147976],[-91.2141893376036,30.562992834836322],[-91.21676425825763,30.559814812515683],[-91.21440391432446,30.55663668610957],[-91.2024734486266,30.559593086143792],[-91.2056920994444,30.565357807147976]]],\"type\":\"Polygon\"}}]}}"
+                    },
+                    "_leading_underscore": { "S": "Do not index" },
+                    "databaseId": { "S": "asdf" }
+                },
+                "SequenceNumber": "551972600000000009030779036",
+                "SizeBytes": 926,
+                "StreamViewType": "NEW_IMAGE"
+            },
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109"
+        }
+    ]
+}

--- a/backend/tests/handlers/indexing/test_streams_fixtures/example_event.json
+++ b/backend/tests/handlers/indexing/test_streams_fixtures/example_event.json
@@ -30,7 +30,7 @@
                 "SizeBytes": 926,
                 "StreamViewType": "NEW_IMAGE"
             },
-            "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109"
+            "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable.../stream/2023-06-21T01:08:09.109"
         }
     ]
 }

--- a/backend/tests/handlers/indexing/test_streams_fixtures/test_lambda_handler_private_fields_not_indexed_expected.json
+++ b/backend/tests/handlers/indexing/test_streams_fixtures/test_lambda_handler_private_fields_not_indexed_expected.json
@@ -49,5 +49,5 @@
         "SizeBytes": 926,
         "StreamViewType": "NEW_IMAGE"
     },
-    "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109"
+    "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable.../stream/2023-06-21T01:08:09.109"
 }

--- a/backend/tests/handlers/indexing/test_streams_fixtures/test_lambda_handler_private_fields_not_indexed_expected.json
+++ b/backend/tests/handlers/indexing/test_streams_fixtures/test_lambda_handler_private_fields_not_indexed_expected.json
@@ -1,0 +1,53 @@
+{
+    "eventID": "f33f76a1c323cd5c40ba06d06c9f84f7",
+    "eventName": "MODIFY",
+    "eventVersion": "1.1",
+    "eventSource": "aws:dynamodb",
+    "awsRegion": "us-east-1",
+    "dynamodb": {
+        "ApproximateCreationDateTime": 1687310394.0,
+        "Keys": {
+            "assetId": {
+                "S": "x68c65799-7312-4476-882b-411a609ba670"
+            },
+            "databaseId": {
+                "S": "asdf"
+            }
+        },
+        "NewImage": {
+            "Boolean Example": {
+                "S": "true"
+            },
+            "Example String Name": {
+                "S": "example string value"
+            },
+            "Example Number": {
+                "N": "123"
+            },
+            "assetId": {
+                "S": "x68c65799-7312-4476-882b-411a609ba670"
+            },
+            "Business Line": {
+                "S": "Musical Instruments"
+            },
+            "Site ID": {
+                "S": "6"
+            },
+            "Date Example": {
+                "S": "2023-06-28"
+            },
+            "location": {
+                "S": "{\"loc\":[\"-91.2091897\",\"30.5611007\"],\"zoom\":\"14\",\"polygons\":{\"type\":\"FeatureCollection\",\"features\":[{\"id\":\"a5d440f5cb30db2b50ade518bac047e2\",\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"coordinates\":[[[-91.2056920994444,30.565357807147976],[-91.2141893376036,30.562992834836322],[-91.21676425825763,30.559814812515683],[-91.21440391432446,30.55663668610957],[-91.2024734486266,30.559593086143792],[-91.2056920994444,30.565357807147976]]],\"type\":\"Polygon\"}}]}}"
+            },
+            "databaseId": {
+                "S": "asdf"
+            },
+            "assetName": "epic story",
+            "description": "a long time ago"
+        },
+        "SequenceNumber": "551972600000000009030779036",
+        "SizeBytes": 926,
+        "StreamViewType": "NEW_IMAGE"
+    },
+    "eventSourceARN": "arn:aws:dynamodb:us-east-1:1234123123:table/vams-dev-us-east-1-MetadataStorageTable8114119D-SVTAR5CJTH10/stream/2023-06-21T01:08:09.109"
+}

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -261,7 +261,8 @@ export class VAMS extends cdk.Stack {
             `/${props.stackName}/pipelineService`,
             `/${props.stackName}/workflowService`,
             `/${props.stackName}/listExecutions`,
-            `/${props.stackName}/ndxng`,
+            `/${props.stackName}/idxa`,
+            `/${props.stackName}/idxm`,
         ];
         for (const path of refactorPaths) {
             const reason = `Intention is to refactor this model away moving forward 

--- a/infra/lib/lambdaBuilder/metadataFunctions.ts
+++ b/infra/lib/lambdaBuilder/metadataFunctions.ts
@@ -45,11 +45,12 @@ export function buildMetadataFunction(
 export function buildMetadataIndexingFunction(
     scope: Construct,
     storageResources: storageResources,
-    aossEndpoint: string
+    aossEndpoint: string,
+    handlerType: "a" | "m"
 ): lambda.Function {
-    const fun = new lambda.DockerImageFunction(scope, "ndxng", {
+    const fun = new lambda.DockerImageFunction(scope, "idx" + handlerType, {
         code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, `../../../backend/`), {
-            cmd: ["backend.handlers.indexing.streams.lambda_handler"],
+            cmd: [`backend.handlers.indexing.streams.lambda_handler_${handlerType}`],
         }),
         timeout: Duration.minutes(15),
         memorySize: 3008,

--- a/web/src/components/single/Metadata.tsx
+++ b/web/src/components/single/Metadata.tsx
@@ -169,6 +169,11 @@ const MetadataTable = ({ assetId, databaseId, store, prefix, initialState }: Met
             if (value === undefined || value === null) {
                 return;
             }
+            if (reqs.indexOf("no-underscore-prefix") > -1) {
+                if (value.indexOf("_") === 0) {
+                    return "Field name must not start with underscore";
+                }
+            }
             if (reqs.indexOf("non-empty") > -1) {
                 if (value.length < 1) {
                     return "Field must not be empty";
@@ -242,7 +247,11 @@ const MetadataTable = ({ assetId, databaseId, store, prefix, initialState }: Met
                             ariaLabel: "Name",
                             editIconAriaLabel: "editable",
                             errorIconAriaLabel: "Name Error",
-                            validation: validationFunction("name", ["non-empty", "unique"]),
+                            validation: validationFunction("name", [
+                                "non-empty",
+                                "unique",
+                                "no-underscore-prefix",
+                            ]),
                             editingCell: (item, { currentValue, setValue }) => {
                                 return (
                                     <Input

--- a/web/src/pages/search/SearchPageListView.tsx
+++ b/web/src/pages/search/SearchPageListView.tsx
@@ -118,12 +118,16 @@ function SearchPageListView({ state, dispatch }: SearchPageViewProps) {
                         options: [
                             {
                                 label: "All columns",
-                                options: columnDefinitions.map(
-                                    (columnDefinition: TableProps.ColumnDefinition<string>) => ({
-                                        id: columnDefinition.id,
-                                        label: columnDefinition.header,
-                                    })
-                                ),
+                                options: columnDefinitions
+                                    .map(
+                                        (
+                                            columnDefinition: TableProps.ColumnDefinition<string>
+                                        ) => ({
+                                            id: columnDefinition.id,
+                                            label: columnDefinition.header,
+                                        })
+                                    )
+                                    .sort((a: any, b: any) => a.label.localeCompare(b.label)),
                             },
                         ],
                     }}


### PR DESCRIPTION
*Description of changes:*

This change makes improvements to a number of indexing scenarios

- single file asset
- multi file asset
- metadata update
- metadata leaf update
- metadata branch update
- metadata trunc/branch update following leaf update
- delete s3 object
  - delete via s3 api
   - moved to glacier
     - moved to glacier via vams, requires a vams-status=deleted attribute on the s3 object to remove it
- delete asset
- no metadata
- controlled metadata
- unstructured metadata
- asset/metadata records arrive after the s3 objects finish uploading
  - assuming the records arrive within a minute of the s3 event
- metadata record writes before the asset record is present
  - assuming the records arrive within a minute of the s3 event

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
