### PR TITLE
fix: Metadata component loading

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -57,7 +57,6 @@ function App() {
     return (
         <Authenticator components={components} loginMechanisms={["email"]} hideSignUp={true}>
             {({ signOut, user }) => {
-                console.info("user", user);
                 const menuText =
                     user.signInUserSession?.idToken?.payload?.name || user.username || user.email;
                 return (

--- a/web/src/common/typeUtils.ts
+++ b/web/src/common/typeUtils.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+interface AxiosError extends Error {
+    response: {
+        config: unknown;
+        data: string | Record<string, unknown>;
+        headers: Record<string, string>;
+        request: XMLHttpRequest;
+        status: number;
+        statusText: string;
+    };
+}
+
+/**
+ * Amplify uses Axios under the hood to power it's API client, but it doesn't
+ * pass through Axios's error types, and attempting to type-narrow just based
+ * on properties of the object makes Webpack complain. This type-assertion
+ * gives us type-safety and satisfies Webpack.
+ * @param e a possible `AxiosError`
+ * @returns true if `e` is an `AxiosError`
+ */
+export function isAxiosError(e: unknown): e is AxiosError {
+    return e instanceof Error && "response" in e;
+}

--- a/web/src/components/list/list-definitions/WorkflowExecutionListDefinition.js
+++ b/web/src/components/list/list-definitions/WorkflowExecutionListDefinition.js
@@ -34,7 +34,6 @@ export const WorkflowExecutionListDefinition = new ListDefinition({
                     return <></>;
                 }
                 if (!item.workflowId) {
-                    console.log(item);
                     if (
                         !item.Items ||
                         !Array.isArray(item.Items) ||

--- a/web/src/components/metadata/CSVControlData.tsx
+++ b/web/src/components/metadata/CSVControlData.tsx
@@ -65,6 +65,14 @@ export function createPapaParseConfig(
             );
             setRawControlData(results.data);
         },
+        error: (error) => {
+            if (error.message === "Not Found") {
+                setControlledLists({});
+                setRawControlData([]);
+            } else {
+                console.error(error);
+            }
+        },
     };
     return config;
 }

--- a/web/src/components/metadata/ControlledMetadata.tsx
+++ b/web/src/components/metadata/ControlledMetadata.tsx
@@ -2,14 +2,14 @@
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { SchemaContextData } from "../../pages/MetadataSchema";
 import { API, Storage } from "aws-amplify";
 import { Container, Grid, Header } from "@cloudscape-design/components";
-import React from "react";
 import { EditComp } from "./EditComp";
 import { HandleControlData, handleCSVControlData as originHandler } from "./CSVControlData";
 import MetadataTable, { MetadataApi, put } from "../single/Metadata";
+import { isAxiosError } from "../../common/typeUtils";
 
 export interface Metadata {
     [k: string]: string;
@@ -56,10 +56,6 @@ export default function ControlledMetadata({
     const [metadata, setMetadata] = useState<Metadata | null>();
     const [items, setItems] = useState<TableRow[]>([]);
 
-    // console.log("schema", schema);
-    // console.log("items", items);
-    // console.log("controlledLists", controlledLists);
-
     const metaToTableRow = (meta: Metadata, schema: SchemaContextData) => {
         schema.schemas.sort((a, b) => {
             if (a.sequenceNumber === undefined) {
@@ -71,7 +67,7 @@ export default function ControlledMetadata({
             return a.sequenceNumber - b.sequenceNumber;
         });
 
-        return schema.schemas
+        const controlled = schema.schemas
             .map((x) => x.field)
             .map((key, idx): TableRow => {
                 return {
@@ -87,6 +83,8 @@ export default function ControlledMetadata({
                     type: schema.schemas.find((x) => x.field === key)?.dataType || "string",
                 };
             });
+
+        return controlled;
     };
 
     const tableRowToMeta = (rows: TableRow[]): Metadata => {
@@ -106,31 +104,57 @@ export default function ControlledMetadata({
             return;
         }
 
-        if (initialState === undefined) {
-            let path = `metadata/${databaseId}/${assetId}`;
-            if (prefix) {
-                path += `?prefix=${prefix}`;
-            }
-            apiget("api", path, {})
-                .then(({ metadata: start }: MetadataApi) => {
-                    apiget("api", `metadataschema/${databaseId}`, {})
-                        .then((data: SchemaContextData) => {
-                            setSchema(data);
-                            if (data.schemas.length > 0) {
-                                const meta = data.schemas.reduce((acc, x) => {
-                                    acc[x.field] = start[x.field] || "";
-                                    return acc;
-                                }, start);
-                                console.log("metadata in init", meta);
-                                setMetadata(meta);
-                                setItems(metaToTableRow(meta, data));
-                            }
-                        })
-                        .catch((error) => console.error(error));
-                })
-                .catch((error) => console.error(error));
-        } else {
-            apiget("api", `metadataschema/${databaseId}`, {}).then((data: SchemaContextData) => {
+        const getMetadata = async () => {
+            if (initialState === undefined) {
+                let path = `metadata/${databaseId}/${assetId}`;
+                if (prefix) {
+                    path += `?prefix=${prefix}`;
+                }
+
+                let start: Metadata = {};
+
+                try {
+                    const { metadata }: MetadataApi = await apiget("api", path, {});
+                    start = metadata;
+                } catch (e) {
+                    if (
+                        isAxiosError(e) &&
+                        e.response.status === 404 &&
+                        e.response.data === "Item Not Found"
+                    ) {
+                        console.warn("No metadata found.");
+                    } else {
+                        throw e;
+                    }
+                }
+
+                try {
+                    const data: SchemaContextData = await apiget(
+                        "api",
+                        `metadataschema/${databaseId}`,
+                        {}
+                    );
+
+                    setSchema(data);
+
+                    if (data.schemas.length > 0) {
+                        const meta = data.schemas.reduce((acc, x) => {
+                            acc[x.field] = start[x.field] || "";
+                            return acc;
+                        }, start);
+                        setMetadata(meta);
+                        setItems(metaToTableRow(meta, data));
+                    }
+                } catch (error) {
+                    setSchema({ databaseId, schemas: [] });
+                    console.error(error);
+                }
+            } else {
+                const data: SchemaContextData = await apiget(
+                    "api",
+                    `metadataschema/${databaseId}`,
+                    {}
+                );
                 setSchema(data);
                 if (data.schemas.length > 0) {
                     const start: Metadata = initialState || {};
@@ -141,8 +165,10 @@ export default function ControlledMetadata({
                     setMetadata(meta);
                     setItems(metaToTableRow(meta, data));
                 }
-            });
-        }
+            }
+        };
+        getMetadata();
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [databaseId, assetId, initialState]);
 
@@ -173,13 +199,7 @@ export default function ControlledMetadata({
 
     return (
         <React.Fragment>
-            <Container
-                header={
-                    <Header variant="h2" description="Metadata">
-                        Metadata
-                    </Header>
-                }
-            >
+            <Container header={<Header variant="h2">Metadata</Header>}>
                 {items.map((row) => {
                     return (
                         <Grid gridDefinition={[{ colspan: 3 }, { colspan: 6 }]} key={row.idx}>

--- a/web/src/pages/AssetUpload.tsx
+++ b/web/src/pages/AssetUpload.tsx
@@ -6,29 +6,27 @@
 import { createContext, Dispatch, useContext, useEffect, useReducer, useState } from "react";
 import {
     Box,
+    Button,
     ColumnLayout,
+    Container,
+    FormField,
     Grid,
+    Header,
+    Input,
     Modal,
+    ProgressBarProps,
     Select,
+    SpaceBetween,
+    StatusIndicatorProps,
     Textarea,
     TextContent,
     Toggle,
+    Wizard,
 } from "@cloudscape-design/components";
 import { useLocation, useNavigate, useParams } from "react-router";
-import Container from "@cloudscape-design/components/container";
-import Header from "@cloudscape-design/components/header";
-import SpaceBetween from "@cloudscape-design/components/space-between";
-import Button from "@cloudscape-design/components/button";
-
-import Wizard from "@cloudscape-design/components/wizard";
-
-import FormField from "@cloudscape-design/components/form-field";
-import Input from "@cloudscape-design/components/input";
 import DatabaseSelector from "../components/selectors/DatabaseSelector";
 import { previewFileFormats } from "../common/constants/fileFormats";
 import { Metadata } from "../components/single/Metadata";
-import { ProgressBarProps } from "@cloudscape-design/components/progress-bar";
-import { StatusIndicatorProps } from "@cloudscape-design/components/status-indicator";
 import { OptionDefinition } from "@cloudscape-design/components/internal/components/option/interfaces";
 import { validateNonZeroLengthTextAsYouType } from "./AssetUpload/validations";
 import { DisplayKV, FileUpload } from "./AssetUpload/components";
@@ -162,7 +160,6 @@ const assetDetailReducer = (
     assetDetailState: AssetDetail,
     assetDetailAction: AssetDetailAction
 ): AssetDetail => {
-    console.log(assetDetailAction);
     switch (assetDetailAction.type) {
         case "UPDATE_ASSET_ID":
             return {
@@ -250,7 +247,6 @@ const assetDetailReducer = (
         default:
             return assetDetailState;
     }
-    return assetDetailState;
 };
 
 type AssetDetailContextType = {
@@ -417,7 +413,6 @@ const AssetMetadataInfo = ({
                     initialState={metadata}
                     store={(databaseId, assetId, record) => {
                         return new Promise((resolve) => {
-                            console.log("resolve promise", resolve);
                             setMetadata(record);
                             resolve(null);
                         });
@@ -445,7 +440,6 @@ const getFilesFromFileHandles = async (fileHandles: any[]) => {
             total: file.size,
         });
     }
-    console.log(fileUploadTableItems);
     return fileUploadTableItems;
 };
 
@@ -585,24 +579,16 @@ const AssetUploadReview = ({
 const UploadForm = () => {
     const assetDetailContext = useContext(AssetDetailContext) as AssetDetailContextType;
     const { assetDetailState, assetDetailDispatch } = assetDetailContext;
-
     const [activeStepIndex, setActiveStepIndex] = useState(0);
-
     const [metadata, setMetadata] = useState<Metadata>({});
-
     const [fileUploadTableItems, setFileUploadTableItems] = useState<FileUploadTableItem[]>([]);
-
     const [freezeWizardButtons, setFreezeWizardButtons] = useState(false);
-
     const [showUploadAndExecProgress, setShowUploadAndExecProgress] = useState(false);
-
     const [uploadExecutionProps, setUploadExecutionProps] = useState<UploadExecutionProps>();
-
     const [previewUploadProgress, setPreviewUploadProgress] = useState<ProgressBarProps>({
         value: 0,
         status: "in-progress",
     });
-
     const [isCancelVisible, setCancelVisible] = useState(false);
 
     useEffect(() => {
@@ -615,7 +601,7 @@ const UploadForm = () => {
                 })
                 .then(() => {})
                 .catch(() => {
-                    console.log("Error setting item in localforage");
+                    console.error("Error setting item in localforage");
                 });
         }
     }, [fileUploadTableItems]);
@@ -724,7 +710,6 @@ const UploadForm = () => {
                     }}
                     onNavigate={({ detail }) => {
                         setActiveStepIndex(detail.requestedStepIndex);
-                        console.log("detail on navigate", detail);
                     }}
                     activeStepIndex={activeStepIndex}
                     onSubmit={onSubmit({
@@ -753,7 +738,8 @@ const UploadForm = () => {
                             content: (
                                 <AssetMetadataInfo metadata={metadata} setMetadata={setMetadata} />
                             ),
-                            isOptional: true,
+                            // Making this mandatory for now until form validation is implemented.
+                            isOptional: false,
                         },
                         {
                             title: "Select Files to upload",


### PR DESCRIPTION
*Description of changes:*
This fixes an issue when rendering the ControlledMetadata component when there is no CSV schema in S3. A missing CSV would cause the request to throw and there was no error-handling to continue the render if it failed. There were similar error-handling problems when an asset had inconsistent metadata, or no schema.

Other changes:
- Removed some debugging console logs.
- Added a type assertion for AxiosErrors to make error-handling easier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
