### PR TITLE
Fix for metadata race condition

### DIFF
--- a/web/src/components/metadata/ControlledMetadata.tsx
+++ b/web/src/components/metadata/ControlledMetadata.tsx
@@ -267,10 +267,12 @@ export default function ControlledMetadata({
                                     setValid={(valid: boolean) => {
                                         if (valid) {
                                             if (!validRows.includes(row.name)) {
-                                                setValidRows([...validRows, row.name]);
+                                                setValidRows((prev) => [...prev, row.name]);
                                             }
                                         } else {
-                                            setValidRows(validRows.filter((r) => r !== row.name));
+                                            setValidRows((prev) =>
+                                                prev.filter((r) => r !== row.name)
+                                            );
                                         }
                                     }}
                                     showErrors={showErrors}

--- a/web/src/components/metadata/EditComp.tsx
+++ b/web/src/components/metadata/EditComp.tsx
@@ -39,13 +39,8 @@ export function EditComp({
     setValid,
 }: EditCompProps) {
     const [validationText, setValidationText] = useState("");
-    const [required, setRequired] = useState(false);
     const disabled = !item.dependsOn.every((x: string) => metadata[x] && metadata[x] !== "");
-
-    useEffect(() => {
-        setRequired(!!schema.schemas.find((s) => s.field === item.name)?.required);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [schema]);
+    const required = !!schema.schemas.find((s) => s.field === item.name)?.required;
 
     useEffect(() => {
         switch (item.type) {
@@ -75,6 +70,7 @@ export function EditComp({
             }
             case "date": {
                 setValidationText(!item.value ? "You must enter a valid date." : "");
+                break;
             }
         }
     }, [item.type, item.value]);

--- a/web/src/pages/AssetUpload.tsx
+++ b/web/src/pages/AssetUpload.tsx
@@ -507,7 +507,6 @@ const AssetFileInfo = ({
     const { assetDetailState, assetDetailDispatch } = assetDetailContext;
 
     useEffect(() => {
-        console.log(assetDetailState);
         if (assetDetailState.Asset?.length && assetDetailState.Asset.length > 0) {
             setValid(true);
         } else {
@@ -660,10 +659,6 @@ const UploadForm = () => {
     const [isCancelVisible, setCancelVisible] = useState(false);
     const [showErrorsForPage, setShowErrorsForPage] = useState(-1);
     const [validSteps, setValidSteps] = useState([false, false, false]);
-
-    useEffect(() => {
-        console.log("Valid steps", validSteps);
-    });
 
     useEffect(() => {
         if (assetDetailState.assetId && fileUploadTableItems.length > 0) {


### PR DESCRIPTION
*Description of changes:*

The ControlledMetadata component was setting the state of the valid fields directly, which worked fine when entering the values, however if the user navigated to the next step in the wizard and then back, the rows would fight over the current value of the validity array, resulting in a race condition. Switching the state setter to use a function instead of a value fixes this race condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
