### PR TITLE
Asset-scoped Temporary Credentials for Upload/Download of Asset Resources from S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
                   export STACK_NAME=CfnNagTest
                   export REGION=us-east-1
                   export VAMS_ADMIN_EMAIL=user@example.com
-                  npx cdk synth
+                  npx cdk@2.94.0 synth
 
             - name: eslint
               working-directory: vams

--- a/backend/backend/handlers/assets/assetService.py
+++ b/backend/backend/handlers/assets/assetService.py
@@ -185,9 +185,9 @@ def archive_multi_file(location, databaseId, assetId):
     paginator = s3.get_paginator('list_objects_v2')
     files = []
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        for obj in page['Contents']:
+        for obj in page.get('Contents', []):
             files.append(obj['Key'])
-    
+
     for key in files:
         try:
             response = move_to_glacier_and_mark_deleted(bucket, key, databaseId, assetId)

--- a/backend/backend/handlers/auth/scopeds3access.py
+++ b/backend/backend/handlers/auth/scopeds3access.py
@@ -1,0 +1,143 @@
+#  Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+
+from backend.handlers.auth import get_database_set, request_to_claims
+import json
+import boto3
+import os
+from datetime import datetime
+
+"""
+given a assetId, databaseId determine if a user has access to mutate s3
+objects for that asset
+
+POST /auth/scopeds3access
+{
+    "assetId": "...",
+    "databaseId": "...",
+}
+"""
+
+ROLE_ARN = os.environ['ROLE_ARN']
+
+
+def lambda_handler(event, context):
+    print(event)
+    response = {
+        'statusCode': 200,
+        'body': '',
+        'headers': {
+            'Content-Type': 'application/json',
+                'Access-Control-Allow-Credentials': True,
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Headers': 'Content-Type',
+                'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+        }
+    }
+
+    try:
+
+        if "body" not in event:
+            response['body'] = json.dumps({
+                "message": "No Body",
+            })
+            response['statusCode'] = 400
+            return response
+
+        body = json.loads(event["body"])
+        assetId = body.get("assetId", None)
+        databaseId = body.get("databaseId", None)
+
+        if assetId is None:
+            response['body'] = json.dumps({
+                "message": "No Asset Id",
+            })
+            response['statusCode'] = 400
+            return response
+
+        if databaseId is None:
+            response['body'] = json.dumps({
+                "message": "No Database Id",
+            })
+            response['statusCode'] = 400
+            return response
+
+        claims_and_roles = request_to_claims(event)
+        tokens = claims_and_roles['tokens']
+
+        databases = get_database_set(tokens)
+        if databaseId not in databases:
+            response['body'] = json.dumps({
+                "message": "Not Authorized",
+            })
+            response['statusCode'] = 403
+            return response
+
+        timeout = 900
+
+        # generate a policy scoped to the assetId as the s3 key prefix
+        # to be passed to assume_role
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Sid": "Stmt1",
+                "Effect": "Allow",
+                # set of actions needed to do get object and multipart upload
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:CreateMultipartUpload",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts",
+                    "s3:DeleteObject",
+                    "s3:ListBucket",
+                ],
+                "Resource": [
+                    "arn:aws:s3:::" +
+                    os.environ['S3_BUCKET'] + "/" + assetId + "/*",
+                    "arn:aws:s3:::" +
+                    os.environ['S3_BUCKET'] + "/previews/" + assetId + "/*"
+
+                ]
+            }]
+        }
+
+        # use sts to create a session for timeout seconds
+        sts_client = boto3.client('sts')
+        assumed_role_object = sts_client.assume_role(
+            RoleArn=ROLE_ARN,
+            RoleSessionName="presign",
+            DurationSeconds=timeout,
+            Policy=json.dumps(policy),
+        )
+
+        print("assumed role object", assumed_role_object)
+
+        def datetime_serializer(obj):
+            if isinstance(obj, datetime):
+                return obj.isoformat()
+            raise TypeError("Type not serializable")
+
+        assumed_role_object['bucket'] = os.environ['S3_BUCKET']
+        assumed_role_object['region'] = os.environ['AWS_REGION']
+
+        # return the credentials
+        response['body'] = json.dumps(assumed_role_object,
+                                      default=datetime_serializer)
+
+        return response
+
+    except Exception as e:
+        response['statusCode'] = 500
+        print("Error!", e.__class__, "occurred.")
+        try:
+            print(e)
+            response['body'] = json.dumps({"message": str(e)})
+        except Exception:
+            print("Can't Read Error")
+            response['body'] = json.dumps({
+                "message": "An unexpected error occurred "
+                           "while executing the request"
+            })
+        return response

--- a/infra/lib/api-builder.ts
+++ b/infra/lib/api-builder.ts
@@ -444,6 +444,13 @@ export function apiBuilder(
     });
 
     const authFunctions = buildAuthFunctions(scope, storageResources);
+
+    attachFunctionToApi(scope, authFunctions.scopeds3access, {
+        routePath: "/auth/scopeds3access",
+        method: apigwv2.HttpMethod.POST,
+        api: api.apiGatewayV2,
+    });
+
     attachFunctionToApi(scope, authFunctions.groups, {
         routePath: "/auth/groups",
         method: apigwv2.HttpMethod.GET,

--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -88,6 +88,7 @@ export class VAMS extends cdk.Stack {
         new cognito.CfnUserPoolGroup(this, "AdminGroup", {
             groupName: "super-admin",
             userPoolId: cognitoResources.userPoolId,
+            roleArn: cognitoResources.superAdminRole.roleArn,
         });
 
         const userGroupAttachment = new cognito.CfnUserPoolUserToGroupAttachment(

--- a/infra/lib/lambdaBuilder/authFunctions.ts
+++ b/infra/lib/lambdaBuilder/authFunctions.ts
@@ -4,6 +4,7 @@
  */
 
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as path from "path";
 import { Construct } from "constructs";
 import { Duration } from "aws-cdk-lib";
@@ -12,21 +13,43 @@ import { storageResources } from "../storage-builder";
 interface AuthFunctions {
     groups: lambda.Function;
     constraints: lambda.Function;
+    scopeds3access: lambda.Function;
 }
 export function buildAuthFunctions(
     scope: Construct,
     storageResources: storageResources
 ): AuthFunctions {
+    const storageBucketRole = new iam.Role(scope, "storageBucketRole", {
+        assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+    });
+
+    storageResources.s3.assetBucket.grantReadWrite(storageBucketRole);
+
+    const scopeds3access = buildAuthFunction(scope, storageResources, "scopeds3access", {
+        ROLE_ARN: storageBucketRole.roleArn,
+        S3_BUCKET: storageResources.s3.assetBucket.bucketName,
+    });
+
+    storageBucketRole.assumeRolePolicy?.addStatements(
+        new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ["sts:AssumeRole"],
+            principals: [scopeds3access.role!],
+        })
+    );
+
     return {
         groups: buildAuthFunction(scope, storageResources, "groups"),
         constraints: buildAuthFunction(scope, storageResources, "finegrainedaccessconstraints"),
+        scopeds3access,
     };
 }
 
 export function buildAuthFunction(
     scope: Construct,
     storageResources: storageResources,
-    name: string
+    name: string,
+    environment?: { [key: string]: string }
 ): lambda.Function {
     const fun = new lambda.DockerImageFunction(scope, name, {
         code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, `../../../backend/`), {
@@ -38,6 +61,7 @@ export function buildAuthFunction(
             TABLE_NAME: storageResources.dynamo.authEntitiesStorageTable.tableName,
             ASSET_STORAGE_TABLE_NAME: storageResources.dynamo.assetStorageTable.tableName,
             DATABASE_STORAGE_TABLE_NAME: storageResources.dynamo.databaseStorageTable.tableName,
+            ...environment,
         },
     });
     storageResources.dynamo.authEntitiesStorageTable.grantReadWriteData(fun);

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -82,10 +82,10 @@
             "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
             "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
         },
-        "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-            "version": "2.0.165",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.165.tgz",
-            "integrity": "sha512-bsyLQD/vqXQcc9RDmlM1XqiFNO/yewgVFXmkMcQkndJbmE/jgYkzewwYGrBlfL725hGLQipXq19+jwWwdsXQqg=="
+        "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+            "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
         },
         "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
             "version": "2.47.0-alpha.0",
@@ -3001,9 +3001,9 @@
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.87.0.tgz",
-            "integrity": "sha512-9kirXX7L7OP/yGmCbaYlkt5OAtowGiGw0AYFIQvSwvx/UU3aJO5XuDwAgDsvToDkRpBi0yX0bNwqa0DItu+C6A==",
+            "version": "2.92.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.92.0.tgz",
+            "integrity": "sha512-J+SUFSnOt9u2GbY5QIABgjGNiw8bL/v0S3zsPhhO1dVwK+G7oE+bhLcAi3iILrw2sIpirNWH9K3W0by9K+cyMw==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "case",
@@ -3017,9 +3017,9 @@
                 "yaml"
             ],
             "dependencies": {
-                "@aws-cdk/asset-awscli-v1": "^2.2.177",
-                "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-                "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+                "@aws-cdk/asset-awscli-v1": "^2.2.200",
+                "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+                "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
                 "@balena/dockerignore": "^1.0.2",
                 "case": "1.6.3",
                 "fs-extra": "^11.1.1",
@@ -3027,7 +3027,7 @@
                 "jsonschema": "^1.4.1",
                 "minimatch": "^3.1.2",
                 "punycode": "^2.3.0",
-                "semver": "^7.5.1",
+                "semver": "^7.5.4",
                 "table": "^6.8.1",
                 "yaml": "1.10.2"
             },
@@ -3243,7 +3243,7 @@
             }
         },
         "node_modules/aws-cdk-lib/node_modules/semver": {
-            "version": "7.5.2",
+            "version": "7.5.4",
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -5391,9 +5391,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -6238,9 +6238,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,9 @@
     "dependencies": {
         "@aws-amplify/storage": "^5.4.0",
         "@aws-amplify/ui-react": "^2.1.5",
-        "@aws-sdk/client-s3": "^3.338.0",
+        "@aws-sdk/client-s3": "^3.400.0",
+        "@aws-sdk/lib-storage": "^3.400.0",
+        "@aws-sdk/s3-request-presigner": "^3.400.0",
         "@cloudscape-design/collection-hooks": "^1.0.19",
         "@cloudscape-design/components": "^3.0.196",
         "@cloudscape-design/design-tokens": "^3.0.8",

--- a/web/src/FedAuth/roles.ts
+++ b/web/src/FedAuth/roles.ts
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { Auth } from "aws-amplify";
 
 export async function anyRoleOf(roles: string[]) {

--- a/web/src/common/auth/s3.ts
+++ b/web/src/common/auth/s3.ts
@@ -103,7 +103,7 @@ async function getS3ClientForAsset(
 }
 
 async function getPresignedKey(assetId: string, databaseId: string, key: string): Promise<string> {
-    const { s3Client, bucket, region } = await getS3ClientForAsset(assetId, databaseId);
+    const { s3Client, bucket } = await getS3ClientForAsset(assetId, databaseId);
 
     // presign the key
     const command = new GetObjectCommand({
@@ -111,7 +111,7 @@ async function getPresignedKey(assetId: string, databaseId: string, key: string)
         Key: key,
     });
 
-    const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+    const url = await getSignedUrl(s3Client, command, { expiresIn: 900 });
     return url;
 }
 

--- a/web/src/common/auth/s3.ts
+++ b/web/src/common/auth/s3.ts
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    S3Client,
-    GetObjectCommand,
-} from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { Upload } from "@aws-sdk/lib-storage";
 import { API } from "aws-amplify";

--- a/web/src/common/auth/s3.ts
+++ b/web/src/common/auth/s3.ts
@@ -1,0 +1,226 @@
+import {
+    S3Client,
+    GetObjectCommand,
+    ListMultipartUploadsCommand,
+    ListPartsCommand,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { Upload } from "@aws-sdk/lib-storage";
+import { API } from "aws-amplify";
+
+interface GetCredentials {
+    assetId: string;
+    databaseId: string;
+}
+
+async function getCredentials(assetIdentifiers: GetCredentials): Promise<any> {
+    console.log("asset identifiers", assetIdentifiers);
+    return API.post("api", "auth/scopeds3access", { body: assetIdentifiers });
+}
+
+function createS3Client(
+    accessKeyId: string,
+    secretAccessKey: string,
+    sessionToken: string,
+    region: string
+): S3Client {
+    return new S3Client({
+        credentials: {
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey,
+            sessionToken,
+        },
+        region: region,
+    });
+}
+
+interface UploadParams {
+    s3: S3Client;
+    Bucket: string;
+    Key: string;
+    Body: Blob | Buffer | ReadableStream;
+    metadata: { [p: string]: string };
+}
+
+class ProgressCallbackArgs {
+    loaded!: number;
+    total!: number;
+}
+
+async function uploadToS3(
+    params: UploadParams,
+    progressCallback: (index: number, progress: ProgressCallbackArgs) => void,
+    completeCallback: (index: number, event: any) => void,
+    errorCallback: (index: number, event: any) => void
+): Promise<void> {
+    const uploader = new Upload({
+        client: params.s3,
+        params: {
+            Bucket: params.Bucket,
+            Key: params.Key,
+            Body: params.Body,
+            Metadata: params.metadata,
+        },
+    });
+
+    uploader.on("httpUploadProgress", (progressEvent) => {
+        if (
+            progressEvent &&
+            progressEvent.loaded &&
+            progressEvent.total &&
+            progressEvent.part &&
+            progressCallback !== undefined
+        ) {
+            progressCallback(progressEvent.part, {
+                loaded: progressEvent.loaded,
+                total: progressEvent.total,
+            });
+        }
+    });
+
+    try {
+        const result = await uploader.done();
+        completeCallback(0, result);
+    } catch (e) {
+        errorCallback(0, e);
+    }
+}
+
+async function getOngoingUploadId(
+    s3: S3Client,
+    Bucket: string,
+    Key: string
+): Promise<string | null> {
+    const command = new ListMultipartUploadsCommand({ Bucket: Bucket });
+    const response = await s3.send(command);
+
+    const ongoingUpload = response.Uploads?.find((upload) => upload.Key === Key);
+    return ongoingUpload?.UploadId || null;
+}
+
+async function getUploadedParts(
+    s3: S3Client,
+    Bucket: string,
+    Key: string,
+    uploadId: string
+): Promise<number[]> {
+    const command = new ListPartsCommand({
+        Bucket: Bucket,
+        Key: Key,
+        UploadId: uploadId,
+    });
+
+    const response = await s3.send(command);
+    if (response.Parts) {
+        return response.Parts.map((part) => part.PartNumber || 0);
+    }
+    return [];
+}
+
+/*
+async function uploadToS3(params: UploadParams, onProgress: (progress: number) => void): Promise<void> {
+    // Identify if there's an ongoing upload for the given key
+    const uploadId = await getOngoingUploadId(params.s3, params.Bucket, params.Key);
+    let uploadedParts: number[] = [];
+
+    if (uploadId) {
+        // If there's an ongoing upload, get the already uploaded parts
+        uploadedParts = await getUploadedParts(params.s3, params.Bucket, params.Key, uploadId);
+    }
+
+    const uploader = new Upload({
+        client: params.s3,
+        params: {
+            Bucket: params.Bucket,
+            Key: params.Key,
+            Body: params.Body
+        },
+        leavePartsOnError: true, // If set to true, it won't clean up the parts if the multipart upload fails.
+        partSize: 5 * 1024 * 1024,
+        queueSize: 4
+    });
+
+    uploader.on('httpUploadProgress', (progressEvent) => {
+        const progress = (progressEvent.loaded / progressEvent.total) * 100;
+        onProgress(progress);
+    });
+
+    // Skip already uploaded parts
+    if (uploadedParts.length) {
+        uploader['partNumbersToUpload'] = uploader['partNumbersToUpload'].filter((partNumber: number) => !uploadedParts.includes(partNumber));
+    }
+
+    await uploader.done();
+}
+*/
+
+async function getS3ClientForAsset(
+    assetId: string,
+    databaseId: string
+): Promise<{ s3Client: S3Client; region: string; bucket: string }> {
+    const creds = await getCredentials({ assetId, databaseId });
+    return {
+        s3Client: createS3Client(
+            creds.Credentials.AccessKeyId,
+            creds.Credentials.SecretAccessKey,
+            creds.Credentials.SessionToken,
+            creds.region
+        ),
+        region: creds.region,
+        bucket: creds.bucket,
+    };
+}
+
+async function getPresignedKey(assetId: string, databaseId: string, key: string): Promise<string> {
+    const { s3Client, bucket, region } = await getS3ClientForAsset(assetId, databaseId);
+
+    // presign the key
+    const command = new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+    });
+
+    const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+    return url;
+}
+
+async function getUploadTaskPromise(
+    index: number,
+    key: string,
+    f: File,
+    metadata: { [p: string]: string },
+    progressCallback: (index: number, progress: ProgressCallbackArgs) => void,
+    completeCallback: (index: number, event: any) => void,
+    errorCallback: (index: number, event: any) => void
+) {
+    return new Promise(async (resolve, reject) => {
+        const { s3Client, bucket } = await getS3ClientForAsset(
+            metadata.assetId,
+            metadata.databaseId
+        );
+
+        uploadToS3(
+            { s3: s3Client, Bucket: bucket, Key: key, Body: f, metadata },
+
+            (part, progress) => {
+                console.log("progress", progress);
+                progressCallback(index, {
+                    loaded: progress.loaded,
+                    total: progress.total,
+                });
+            },
+            (part, event) => {
+                console.log("complete", part, event);
+                completeCallback(index, null);
+                resolve(true);
+            },
+            (part, event) => {
+                console.log("error", part, event);
+                errorCallback(index, event);
+                resolve(true);
+            }
+        );
+    });
+}
+
+export { createS3Client, uploadToS3, getUploadTaskPromise, getPresignedKey };

--- a/web/src/common/s3/credentials.ts
+++ b/web/src/common/s3/credentials.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { API } from "aws-amplify";
+import { ICredentials } from "./upload";
+
+export interface GetCredentials {
+    assetId: string;
+    databaseId: string;
+}
+
+class UnableToRetrieveCredentialsError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UnableToRetrieveCredentialsError";
+    }
+}
+
+interface ScopedS3Response {
+    Credentials: {
+        AccessKeyId: string;
+        SecretAccessKey: string;
+        SessionToken: string;
+        Expiration: string;
+    };
+    region: string;
+    bucket: string;
+    [key: string]: any;
+}
+
+class AssetCredentials {
+    private credentials: ICredentials | null;
+    private identifiers: GetCredentials;
+
+    constructor(identifiers: GetCredentials) {
+        this.credentials = null;
+        this.identifiers = identifiers;
+    }
+
+    async getCredentials(): Promise<ICredentials> {
+        if (
+            this.credentials &&
+            this.credentials.expiration &&
+            this.credentials.expiration.getTime() > Date.now() + 60000 * 14
+        ) {
+            return this.credentials;
+        }
+
+        const resp: ScopedS3Response = await API.post("api", "auth/scopeds3access", {
+            body: this.identifiers,
+        });
+
+        if (!resp.Credentials) {
+            throw new UnableToRetrieveCredentialsError("No credentials returned from API");
+        }
+        this.credentials = {
+            accessKeyId: resp.Credentials.AccessKeyId,
+            secretAccessKey: resp.Credentials.SecretAccessKey,
+            sessionToken: resp.Credentials.SessionToken,
+            expiration: new Date(resp.Credentials.Expiration),
+            authenticated: true,
+            identityId: resp.AssumedRoleUser.AssumedRoleId,
+        };
+
+        return this.credentials;
+    }
+}
+
+export default AssetCredentials;

--- a/web/src/common/s3/credentials.ts
+++ b/web/src/common/s3/credentials.ts
@@ -4,12 +4,7 @@
  */
 
 import { API } from "aws-amplify";
-import { ICredentials } from "./upload";
-
-export interface GetCredentials {
-    assetId: string;
-    databaseId: string;
-}
+import { ICredentials, GetCredentials } from "./types";
 
 class UnableToRetrieveCredentialsError extends Error {
     constructor(message: string) {

--- a/web/src/common/s3/credentials.ts
+++ b/web/src/common/s3/credentials.ts
@@ -38,7 +38,7 @@ class AssetCredentials {
         if (
             this.credentials &&
             this.credentials.expiration &&
-            this.credentials.expiration.getTime() > Date.now() + 60000 * 14
+            this.credentials.expiration.getTime() > Date.now() + 60000
         ) {
             return this.credentials;
         }

--- a/web/src/common/s3/types.ts
+++ b/web/src/common/s3/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface GetCredentials {
+    assetId: string;
+    databaseId: string;
+}
+
+export interface ICredentials {
+    accessKeyId: string;
+    sessionToken: string;
+    secretAccessKey: string;
+    identityId: string;
+    authenticated: boolean;
+    expiration?: Date;
+}

--- a/web/src/common/s3/upload.ts
+++ b/web/src/common/s3/upload.ts
@@ -5,9 +5,17 @@
 
 /*
 
-This was derived in large part from Amplify's upload functionality. This 
-version was created to leverage @aws-sdk/client-s3 and a different 
+This was derived in large part from Amplify's upload functionality. This
+version was created to leverage @aws-sdk/client-s3 and a different
 credentials model to support the authorization models in VAMS.
+
+- Instead of using the embedded client inside of amplify, we use the
+  @aws-sdk/client-s3 library. Functions to call the S3Client are found in
+  this class.
+
+- The credential model is to pass in a function to the S3Upload constructor
+  that can be called to get fresh credentials. So it can be used with any
+  source of credentials and not just a Cognito user pool as is the case with Amplify.
 
 https://github.com/aws-amplify/amplify-js/blob/main/packages/storage/src/providers/AWSS3Provider.ts
 
@@ -141,16 +149,15 @@ class S3Upload {
             // first time running resume, find any cached parts on s3 or start a new multipart upload request before
             // starting the upload
         } else if (!this.uploadId) {
-            logger.info("resuming upload");
+            logger.debug("resuming upload");
             this._initializeUploadTask();
         } else {
-            logger.info("starting upload");
+            logger.debug("starting upload");
             this._startUpload();
         }
     }
 
     private async _initializeUploadTask() {
-        console.log("initialize");
         this.state = AWSS3UploadTaskState.IN_PROGRESS;
         this.partSize = calculatePartSize(this.totalBytes);
         try {

--- a/web/src/common/s3/upload.ts
+++ b/web/src/common/s3/upload.ts
@@ -1,0 +1,558 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+
+This was derived in large part from Amplify's upload functionality. This 
+version was created to leverage @aws-sdk/client-s3 and a different 
+credentials model to support the authorization models in VAMS.
+
+https://github.com/aws-amplify/amplify-js/blob/main/packages/storage/src/providers/AWSS3Provider.ts
+
+*/
+
+import {
+    Part,
+    UploadPartCommandInput,
+    CompletedPart,
+    ListPartsCommand,
+    S3Client,
+    ListPartsCommandInput,
+    ListPartsCommandOutput,
+    CompleteMultipartUploadCommandInput,
+    CompleteMultipartUploadCommand,
+    CompleteMultipartUploadCommandOutput,
+    ListObjectsV2Command,
+    ListObjectsV2CommandInput,
+    ListObjectsV2CommandOutput,
+    UploadPartCommand,
+    UploadPartCommandOutput,
+    CreateMultipartUploadCommandInput,
+    CreateMultipartUploadCommand,
+} from "@aws-sdk/client-s3";
+import * as events from "events";
+
+export enum AWSS3UploadTaskState {
+    INIT,
+    IN_PROGRESS,
+    PAUSED,
+    CANCELLED,
+    COMPLETED,
+}
+
+export interface ICredentials {
+    accessKeyId: string;
+    sessionToken: string;
+    secretAccessKey: string;
+    identityId: string;
+    authenticated: boolean;
+    expiration?: Date;
+}
+
+export enum TaskEvents {
+    CANCEL = "cancel",
+    UPLOAD_COMPLETE = "uploadComplete",
+    UPLOAD_PROGRESS = "uploadPartProgress",
+    ERROR = "error",
+}
+
+export interface InProgressRequest {
+    uploadPartInput: UploadPartCommandInput;
+    s3Request: Promise<any>;
+    abortController: AbortController;
+}
+
+type UploadTaskProgressEvent = {
+    loaded: number;
+    total: number;
+    index?: number;
+};
+
+export interface UploadTaskCompleteEvent {
+    key?: string;
+}
+
+export interface FileMetadata {
+    bucket: string;
+    fileName: string;
+    key: string;
+    // Unix timestamp in ms
+    lastTouched: number;
+    uploadId: string;
+}
+
+type CredentialsProvider = () => Promise<ICredentials>;
+
+type PutObjectInput = {
+    Bucket: string;
+    Key: string;
+    Body: File;
+    Metadata: { [key: string]: string };
+};
+
+interface S3UploadProps {
+    credentialsProvider: CredentialsProvider;
+    region: string;
+    params: PutObjectInput;
+    storage: Storage;
+    emitter?: events.EventEmitter;
+}
+
+const DEFAULT_QUEUE_SIZE = 4;
+const DEFAULT_PART_SIZE = 5 * 1024 * 1024;
+
+const UPLOADS_STORAGE_KEY = "@@upload";
+const logger = console;
+
+class S3Upload {
+    private readonly emitter: events.EventEmitter;
+    private readonly file: Blob;
+    private readonly queueSize = DEFAULT_QUEUE_SIZE;
+    private readonly storage: Storage;
+    private readonly fileId: string;
+    private readonly params: PutObjectInput;
+
+    private readonly credentialsProvider: CredentialsProvider;
+    private readonly region: string;
+
+    private state = AWSS3UploadTaskState.INIT;
+
+    private partSize: number = DEFAULT_PART_SIZE;
+    private inProgress: InProgressRequest[] = [];
+    private completedParts: CompletedPart[] = [];
+    private queued: UploadPartCommandInput[] = [];
+    private bytesUploaded: number = 0;
+    private totalBytes: number = 0;
+    private uploadId?: string | null;
+
+    constructor({ credentialsProvider, region, params, storage, emitter }: S3UploadProps) {
+        this.credentialsProvider = credentialsProvider;
+        this.params = params;
+        this.file = params.Body;
+        this.totalBytes = this.file.size;
+        this.fileId = this._getFileId();
+        this.storage = storage;
+        this.region = region;
+        this.emitter = emitter || new events.EventEmitter();
+    }
+
+    public resume(): void {
+        if (this.state === AWSS3UploadTaskState.CANCELLED) {
+            logger.warn("This task has already been cancelled");
+        } else if (this.state === AWSS3UploadTaskState.COMPLETED) {
+            logger.warn("This task has already been completed");
+        } else if (this.state === AWSS3UploadTaskState.IN_PROGRESS) {
+            logger.warn("Upload task already in progress");
+            // first time running resume, find any cached parts on s3 or start a new multipart upload request before
+            // starting the upload
+        } else if (!this.uploadId) {
+            logger.info("resuming upload");
+            this._initializeUploadTask();
+        } else {
+            logger.info("starting upload");
+            this._startUpload();
+        }
+    }
+
+    private async _initializeUploadTask() {
+        console.log("initialize");
+        this.state = AWSS3UploadTaskState.IN_PROGRESS;
+        this.partSize = calculatePartSize(this.totalBytes);
+        try {
+            if (await this._isCached()) {
+                const { parts, uploadId } = await this._findCachedUploadParts();
+                this.uploadId = uploadId;
+                this.queued = this._createParts();
+                this._initCachedUploadParts(parts);
+                if (this._isDone()) {
+                    this._completeUpload();
+                } else {
+                    this._startUpload();
+                }
+            } else {
+                if (!this.uploadId) {
+                    const uploadId = await this._initMultipartUpload();
+                    this.uploadId = uploadId;
+                    this.queued = this._createParts();
+                    this._startUpload();
+                }
+            }
+        } catch (err) {
+            if (!isCancelError(err)) {
+                logger.error("Error initializing the upload task", err);
+                this._emitEvent(TaskEvents.ERROR, err);
+            }
+        }
+    }
+
+    private async _initMultipartUpload() {
+        const res = await this._createMultipartUpload(this.params);
+        this._cache({
+            uploadId: res.UploadId!,
+            lastTouched: Date.now(),
+            bucket: this.params.Bucket,
+            key: this.params.Key,
+            fileName: this.file instanceof File ? this.file.name : "",
+        });
+        return res.UploadId;
+    }
+
+    private _startUpload() {
+        this.state = AWSS3UploadTaskState.IN_PROGRESS;
+        for (let i = 0; i < this.queueSize; i++) {
+            this._startNextPart();
+        }
+    }
+
+    private _startNextPart() {
+        if (this.queued.length > 0 && this.state !== AWSS3UploadTaskState.PAUSED) {
+            const abortController = new AbortController();
+            const nextPart = this.queued.shift();
+            this.inProgress.push({
+                uploadPartInput: nextPart!,
+                s3Request: this._makeUploadPartRequest(nextPart!, abortController.signal),
+                abortController,
+            });
+        }
+    }
+
+    private async _makeUploadPartRequest(input: UploadPartCommandInput, abortSignal: AbortSignal) {
+        try {
+            const res = await this._uploadPart(abortSignal, input);
+            await this._onPartUploadCompletion({
+                eTag: res.ETag!,
+                partNumber: input.PartNumber!,
+                chunk: input.Body,
+            });
+        } catch (err) {
+            if (this.state === AWSS3UploadTaskState.PAUSED) {
+                logger.log("upload paused");
+            } else if (this.state === AWSS3UploadTaskState.CANCELLED) {
+                logger.log("upload aborted");
+            } else {
+                logger.error("error starting next part of upload: ", err);
+            }
+            // xhr transfer handlers' cancel will also throw an error, however we don't need to emit an event in that case as it's an
+            // expected behavior
+            if (
+                !isCancelError(err) &&
+                err instanceof Error &&
+                err.message !== CANCELED_ERROR_MESSAGE
+            ) {
+                this._emitEvent(TaskEvents.ERROR, err);
+                this.pause();
+            }
+        }
+    }
+
+    private async _onPartUploadCompletion({
+        eTag,
+        partNumber,
+        chunk,
+    }: {
+        eTag: string;
+        partNumber: number;
+        chunk: UploadPartCommandInput["Body"];
+    }) {
+        this.completedParts.push({
+            ETag: eTag,
+            PartNumber: partNumber,
+        });
+        this.bytesUploaded += byteLength(chunk);
+        this._emitEvent<UploadTaskProgressEvent>(TaskEvents.UPLOAD_PROGRESS, {
+            loaded: this.bytesUploaded,
+            total: this.totalBytes,
+        });
+        // Remove the completed item from the inProgress array
+        this.inProgress = this.inProgress.filter(
+            (job) => job.uploadPartInput.PartNumber !== partNumber
+        );
+        if (this.queued.length && this.state !== AWSS3UploadTaskState.PAUSED) this._startNextPart();
+        if (this._isDone()) this._completeUpload();
+    }
+
+    private _initCachedUploadParts(cachedParts: Part[]) {
+        this.bytesUploaded += cachedParts.reduce((acc, part) => acc + part.Size!, 0);
+        // Find the set of part numbers that have already been uploaded
+        const uploadedPartNumSet = new Set(cachedParts.map((part) => part.PartNumber));
+        this.queued = this.queued.filter((part) => !uploadedPartNumSet.has(part.PartNumber));
+        this.completedParts = cachedParts.map((part) => ({
+            PartNumber: part.PartNumber,
+            ETag: part.ETag,
+        }));
+        this._emitEvent<UploadTaskProgressEvent>(TaskEvents.UPLOAD_PROGRESS, {
+            loaded: this.bytesUploaded,
+            total: this.totalBytes,
+        });
+    }
+
+    private async _completeUpload() {
+        try {
+            await this._completeMultipartUpload({
+                Bucket: this.params.Bucket,
+                Key: this.params.Key,
+                UploadId: this.uploadId!,
+                MultipartUpload: {
+                    // Parts are not always completed in order, we need to manually sort them
+                    Parts: [...this.completedParts].sort(comparePartNumber),
+                },
+            });
+            await this._verifyFileSize();
+            this._emitEvent<UploadTaskCompleteEvent>(TaskEvents.UPLOAD_COMPLETE, {
+                key: this.params.Key,
+            });
+            this._removeFromCache();
+            this.state = AWSS3UploadTaskState.COMPLETED;
+        } catch (err) {
+            logger.error("error completing upload", err);
+            this._emitEvent(TaskEvents.ERROR, err);
+        }
+    }
+
+    /**
+     * Verify on S3 side that the file size matches the one on the client side.
+     *
+     * @async
+     * @throws throws an error if the file size does not match between local copy of the file and the file on s3.
+     */
+    private async _verifyFileSize() {
+        let valid = false;
+        const args = {
+            Prefix: this.params.Key,
+            Bucket: this.params.Bucket,
+        };
+        try {
+            const resp = await this._listSingleFile(args);
+            if (resp.Contents && resp.Contents.length > 0) {
+                const obj = resp.Contents[0];
+                valid = Boolean(obj && obj.Size === this.file.size);
+            }
+        } catch (e) {
+            logger.log("Could not get file on s3 for size matching: ", e, args);
+            // Don't gate verification on auth or other errors
+            // unrelated to file size verification
+            return;
+        }
+
+        if (!valid) {
+            throw new Error("File size does not match between local file and file on s3");
+        }
+    }
+
+    private _isDone() {
+        return (
+            !this.queued.length && !this.inProgress.length && this.bytesUploaded === this.totalBytes
+        );
+    }
+
+    private _createParts() {
+        const size = this.file.size;
+        const parts: UploadPartCommandInput[] = [];
+        for (let bodyStart = 0; bodyStart < size; ) {
+            const bodyEnd = Math.min(bodyStart + this.partSize, size);
+            parts.push({
+                Body: this.file.slice(bodyStart, bodyEnd),
+                Key: this.params.Key,
+                Bucket: this.params.Bucket,
+                PartNumber: parts.length + 1,
+                UploadId: this.uploadId!,
+            });
+            bodyStart += this.partSize;
+        }
+        return parts;
+    }
+
+    private async _findCachedUploadParts(): Promise<{
+        parts: Part[];
+        uploadId: string | null;
+    }> {
+        const uploadRequests = await this._listCachedUploadTasks();
+
+        if (
+            Object.keys(uploadRequests).length === 0 ||
+            !Object.prototype.hasOwnProperty.call(uploadRequests, this.fileId)
+        ) {
+            return { parts: [], uploadId: null };
+        }
+
+        const cachedUploadFileData = uploadRequests[this.fileId];
+        cachedUploadFileData.lastTouched = Date.now();
+        this.storage.setItem(UPLOADS_STORAGE_KEY, JSON.stringify(uploadRequests));
+
+        const { Parts = [] } = await this._listParts({
+            Bucket: this.params.Bucket,
+            Key: this.params.Key,
+            UploadId: cachedUploadFileData.uploadId,
+        });
+
+        return {
+            parts: Parts,
+            uploadId: cachedUploadFileData.uploadId,
+        };
+    }
+
+    private async _s3Client(): Promise<S3Client> {
+        const credentials = await this.credentialsProvider();
+
+        const s3 = new S3Client({
+            credentials,
+            region: this.region,
+        });
+
+        return s3;
+    }
+
+    private async _createMultipartUpload(params: CreateMultipartUploadCommandInput) {
+        const s3 = await this._s3Client();
+        return s3.send(new CreateMultipartUploadCommand(params));
+    }
+
+    private async _uploadPart(
+        abortSignal: AbortSignal,
+        params: UploadPartCommandInput
+    ): Promise<UploadPartCommandOutput> {
+        const s3 = await this._s3Client();
+        return s3.send(new UploadPartCommand(params), {
+            abortSignal,
+        });
+    }
+
+    private async _listSingleFile(
+        params: ListObjectsV2CommandInput
+    ): Promise<ListObjectsV2CommandOutput> {
+        const s3 = await this._s3Client();
+        const cmd = new ListObjectsV2Command(params);
+        return s3.send(cmd);
+    }
+
+    private async _completeMultipartUpload(
+        params: CompleteMultipartUploadCommandInput
+    ): Promise<CompleteMultipartUploadCommandOutput> {
+        const s3 = await this._s3Client();
+
+        return s3.send(new CompleteMultipartUploadCommand(params));
+    }
+
+    private async _listParts(input: ListPartsCommandInput): Promise<ListPartsCommandOutput> {
+        const s3 = await this._s3Client();
+
+        const cmd = new ListPartsCommand({
+            ...input,
+        });
+
+        return s3.send(cmd);
+    }
+
+    private async _listCachedUploadTasks(): Promise<Record<string, FileMetadata>> {
+        // await this.storageSync;
+        const tasks = this.storage.getItem(UPLOADS_STORAGE_KEY) || "{}";
+        return JSON.parse(tasks);
+    }
+
+    private async _cache(fileMetadata: FileMetadata): Promise<void> {
+        const uploadRequests = await this._listCachedUploadTasks();
+        uploadRequests[this.fileId] = fileMetadata;
+        this.storage.setItem(UPLOADS_STORAGE_KEY, JSON.stringify(uploadRequests));
+    }
+
+    private async _isCached(): Promise<boolean> {
+        return Object.prototype.hasOwnProperty.call(
+            await this._listCachedUploadTasks(),
+            this.fileId
+        );
+    }
+
+    private async _removeFromCache(): Promise<void> {
+        const uploadRequests = await this._listCachedUploadTasks();
+        delete uploadRequests[this.fileId];
+        this.storage.setItem(UPLOADS_STORAGE_KEY, JSON.stringify(uploadRequests));
+    }
+
+    /**
+     * pause this particular upload task
+     **/
+    public pause(): void {
+        if (this.state === AWSS3UploadTaskState.CANCELLED) {
+            logger.warn("This task has already been cancelled");
+        } else if (this.state === AWSS3UploadTaskState.COMPLETED) {
+            logger.warn("This task has already been completed");
+        } else if (this.state === AWSS3UploadTaskState.PAUSED) {
+            logger.warn("This task is already paused");
+        }
+        this.state = AWSS3UploadTaskState.PAUSED;
+        // Abort the part request immediately
+        // Add the inProgress parts back to pending
+        const removedInProgressReq = this.inProgress.splice(0, this.inProgress.length);
+        removedInProgressReq.forEach((req) => {
+            req.abortController.abort();
+        });
+        // Put all removed in progress parts back into the queue
+        this.queued.unshift(...removedInProgressReq.map((req) => req.uploadPartInput));
+    }
+
+    private _getFileId(): string {
+        // We should check if it's a File first because File is also instance of a Blob
+        if (isFile(this.file)) {
+            return [
+                this.file.name,
+                this.file.lastModified,
+                this.file.size,
+                this.file.type,
+                this.params.Bucket,
+                this.params.Key,
+            ].join("-");
+        } else {
+            return [this.file.size, this.file.type, this.params.Bucket, this.params.Key].join("-");
+        }
+    }
+
+    private _emitEvent<T = any>(event: string, payload: T) {
+        this.emitter.emit(event, payload);
+    }
+}
+
+export const isFile = (x: unknown): x is File => {
+    return typeof x !== "undefined" && x instanceof File;
+};
+
+export const isBlob = (x: unknown): x is Blob => {
+    return typeof x !== "undefined" && x instanceof Blob;
+};
+
+const isArrayBuffer = (x: unknown): x is ArrayBuffer => {
+    return typeof x !== "undefined" && x instanceof ArrayBuffer;
+};
+
+function comparePartNumber(a: CompletedPart, b: CompletedPart) {
+    return a.PartNumber! - b.PartNumber!;
+}
+export const MAX_PARTS_COUNT = 10000;
+export const calculatePartSize = (totalSize: number): number => {
+    let partSize = DEFAULT_PART_SIZE;
+    let partsCount = Math.ceil(totalSize / partSize);
+    while (partsCount > MAX_PARTS_COUNT) {
+        partSize *= 2;
+        partsCount = Math.ceil(totalSize / partSize);
+    }
+    return partSize;
+};
+
+export const byteLength = (x: unknown) => {
+    if (typeof x === "string") {
+        return x.length;
+    } else if (isArrayBuffer(x)) {
+        return x.byteLength;
+    } else if (isBlob(x)) {
+        return x.size;
+    } else {
+        throw new Error("Cannot determine byte length of " + x);
+    }
+};
+
+export const isCancelError = (error: any): boolean => !!error?.["__CANCEL__"];
+
+export const CANCELED_ERROR_MESSAGE = "canceled";
+
+export default S3Upload;

--- a/web/src/common/s3/upload.ts
+++ b/web/src/common/s3/upload.ts
@@ -32,7 +32,9 @@ import {
     CreateMultipartUploadCommandInput,
     CreateMultipartUploadCommand,
 } from "@aws-sdk/client-s3";
+
 import * as events from "events";
+import { ICredentials } from "./types";
 
 export enum AWSS3UploadTaskState {
     INIT,
@@ -40,15 +42,6 @@ export enum AWSS3UploadTaskState {
     PAUSED,
     CANCELLED,
     COMPLETED,
-}
-
-export interface ICredentials {
-    accessKeyId: string;
-    sessionToken: string;
-    secretAccessKey: string;
-    identityId: string;
-    authenticated: boolean;
-    expiration?: Date;
 }
 
 export enum TaskEvents {

--- a/web/src/common/s3/uploadtaskpromise.ts
+++ b/web/src/common/s3/uploadtaskpromise.ts
@@ -4,8 +4,10 @@
  */
 import events from "events";
 import S3Upload, { TaskEvents } from "./upload";
-import AssetCredentials, { GetCredentials } from "./credentials";
+import AssetCredentials from "./credentials";
+
 import { Cache } from "aws-amplify";
+import { GetCredentials } from "./types";
 
 class ProgressCallbackArgs {
     loaded!: number;

--- a/web/src/common/s3/uploadtaskpromise.ts
+++ b/web/src/common/s3/uploadtaskpromise.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import events from "events";
+import S3Upload, { TaskEvents } from "./upload";
+import AssetCredentials, { GetCredentials } from "./credentials";
+import { Cache } from "aws-amplify";
+
+class ProgressCallbackArgs {
+    loaded!: number;
+    total!: number;
+}
+
+export default async function getUploadTaskPromise(
+    index: number,
+    key: string,
+    f: File,
+    metadata: { [p: string]: string } & GetCredentials,
+    progressCallback: (index: number, progress: ProgressCallbackArgs) => void,
+    completeCallback: (index: number, event: any) => void,
+    errorCallback: (index: number, event: any) => void
+): Promise<void> {
+    const creds = new AssetCredentials(metadata);
+
+    const config = Cache.getItem("config");
+
+    const em = new events.EventEmitter();
+    const uploadTask = new S3Upload({
+        credentialsProvider: creds.getCredentials.bind(creds),
+        params: {
+            Body: f,
+            Bucket: config.bucket,
+            Key: key,
+            Metadata: metadata,
+        },
+        region: config.region,
+        storage: localStorage,
+        emitter: em,
+    });
+
+    em.on(TaskEvents.UPLOAD_PROGRESS, (progress) => {
+        progressCallback(index, progress);
+    });
+    em.on(TaskEvents.UPLOAD_COMPLETE, () => {
+        completeCallback(index, {});
+    });
+    em.on(TaskEvents.ERROR, (error) => {
+        errorCallback(index, error);
+    });
+
+    uploadTask.resume();
+}

--- a/web/src/components/single/AssetVisualizer.tsx
+++ b/web/src/components/single/AssetVisualizer.tsx
@@ -48,6 +48,8 @@ function AssetVisualizer(props: AssetVisualizerPropTypes) {
                     )}
                     {props.viewType === "model" && (
                         <ModelViewer
+                            assetId={props.asset.assetId}
+                            databaseId={props.asset.databaseId}
                             assetKey={
                                 props.asset?.generated_artifacts?.gltf?.Key ||
                                 props.asset?.assetLocation?.Key
@@ -57,15 +59,25 @@ function AssetVisualizer(props: AssetVisualizerPropTypes) {
                     )}
                     {props.viewType === "plot" && (
                         <ThreeDimensionalPlotter
+                            assetId={props.asset.assetId}
+                            databaseId={props.asset.databaseId}
                             assetKey={props.asset?.assetLocation?.Key}
                             className="visualizer-container-canvas"
                         />
                     )}
                     {props.viewType === "column" && (
-                        <ColumnarViewer assetKey={props.asset?.assetLocation?.Key} />
+                        <ColumnarViewer
+                            assetId={props.asset.assetId}
+                            databaseId={props.asset.databaseId}
+                            assetKey={props.asset?.assetLocation?.Key}
+                        />
                     )}
                     {props.viewType === "html" && (
-                        <HTMLViewer assetKey={props.asset?.assetLocation?.Key} />
+                        <HTMLViewer
+                            assetId={props.asset.assetId}
+                            databaseId={props.asset.databaseId}
+                            assetKey={props.asset?.assetLocation?.Key}
+                        />
                     )}
                     {props.viewType === "folder" && (
                         <FolderViewer

--- a/web/src/components/single/AssetVisualizer.tsx
+++ b/web/src/components/single/AssetVisualizer.tsx
@@ -37,6 +37,8 @@ function AssetVisualizer(props: AssetVisualizerPropTypes) {
                 <div className="visualizer-container-canvases">
                     {props.viewType === "preview" && props.asset?.previewLocation?.Key && (
                         <ImgViewer
+                            assetId={props.asset.assetId}
+                            databaseId={props.asset.databaseId}
                             assetKey={
                                 props.asset?.generated_artifacts?.preview?.Key ||
                                 props.asset.previewLocation.Key

--- a/web/src/components/single/ViewAsset.js
+++ b/web/src/components/single/ViewAsset.js
@@ -345,6 +345,8 @@ export default function ViewAsset() {
                                                         {viewType === "preview" &&
                                                             asset?.previewLocation?.Key && (
                                                                 <ImgViewer
+                                                                    assetId={assetId}
+                                                                    databaseId={databaseId}
                                                                     assetKey={
                                                                         asset?.generated_artifacts
                                                                             ?.preview?.Key ||

--- a/web/src/components/viewers/ColumnarViewer.js
+++ b/web/src/components/viewers/ColumnarViewer.js
@@ -5,7 +5,7 @@
  */
 
 import React, { useEffect, useState } from "react";
-import { Storage } from "aws-amplify";
+import { getPresignedKey } from "../../common/auth/s3";
 import { readRemoteFile } from "react-papaparse";
 import DataGrid from "react-data-grid";
 import FCS from "fcs";
@@ -82,18 +82,14 @@ const readCsvFile = (remoteFileUrl, setColumns, setRows) => {
 };
 
 export default function ColumnarViewer(props) {
-    const { assetKey } = props;
+    const { assetId, databaseId, assetKey } = props;
     const [loaded, setLoaded] = useState(false);
     const [columns, setColumns] = useState([]);
     const [rows, setRows] = useState([]);
 
     useEffect(() => {
-        let config = {
-            download: false,
-            expires: 10,
-        };
         const loadAsset = async () => {
-            await Storage.get(assetKey, config).then((remoteFileUrl) => {
+            await getPresignedKey(assetId, databaseId, assetKey).then((remoteFileUrl) => {
                 if (assetKey.indexOf(".fcs") !== -1) {
                     try {
                         readFcsFile(remoteFileUrl, setColumns, setRows);

--- a/web/src/components/viewers/FolderActionViewer.tsx
+++ b/web/src/components/viewers/FolderActionViewer.tsx
@@ -1,10 +1,10 @@
 import { Header } from "@cloudscape-design/components";
 import Button from "@cloudscape-design/components/button";
 import Container from "@cloudscape-design/components/container";
-import { Storage } from "aws-amplify";
 import { useEffect, useState } from "react";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import { useNavigate, useParams } from "react-router";
+import { getPresignedKey } from "../../common/auth/s3";
 export class FolderActionProps {
     databaseId!: string;
     assetId!: string;
@@ -14,18 +14,22 @@ export class FolderActionProps {
     isDirectory!: boolean;
 }
 
-export default function FolderActionViewer({ name, urlKey, ...props }: FolderActionProps) {
+export default function FolderActionViewer({
+    assetId,
+    databaseId,
+    name,
+    urlKey,
+    ...props
+}: FolderActionProps) {
     const navigate = useNavigate();
     const [downloadLink, setDownloadLink] = useState<string>("");
 
     function generateDownloadLink(key: string) {
-        Storage.get(key, { download: false }).then((data) => {
-            setDownloadLink(data);
-        });
+        getPresignedKey(assetId, databaseId, key).then(setDownloadLink);
     }
 
     function navigateToAssetFilePage() {
-        navigate(`/databases/${props.databaseId}/assets/${props.assetId}/file`, {
+        navigate(`/databases/${databaseId}/assets/${assetId}/file`, {
             state: { filename: name, key: urlKey, isDirectory: props.isDirectory },
         });
     }

--- a/web/src/components/viewers/HTMLViewer.js
+++ b/web/src/components/viewers/HTMLViewer.js
@@ -4,21 +4,17 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Storage } from "aws-amplify";
 import DOMPurify from "dompurify";
+import { getPresignedKey } from "../../common/auth/s3";
 
 export default function HTMLViewer(props) {
     const shadowElement = useRef(null);
-    const { assetKey } = props;
+    const { assetId, databaseId, assetKey } = props;
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
-        let config = {
-            download: false,
-            expires: 10,
-        };
         const loadAsset = async () => {
-            await Storage.get(assetKey, config).then((remoteFileUrl) => {
+            await getPresignedKey(assetId, databaseId, assetKey).then((remoteFileUrl) => {
                 const request = new XMLHttpRequest();
                 request.onload = function (e) {
                     const cleanContent = DOMPurify.sanitize(request.response);

--- a/web/src/components/viewers/ImgViewer.tsx
+++ b/web/src/components/viewers/ImgViewer.tsx
@@ -1,13 +1,15 @@
 /* eslint-disable jsx-a11y/alt-text */
 import React, { useEffect, useState } from "react";
-import { Storage } from "aws-amplify";
+import { getPresignedKey } from "../../common/auth/s3";
 
 class ImgViewerProps {
+    assetId!: string;
+    databaseId!: string;
     assetKey!: string;
     altAssetKey!: string;
 }
 
-export default function ImgViewer({ assetKey, altAssetKey }: ImgViewerProps) {
+export default function ImgViewer({ assetId, databaseId, assetKey, altAssetKey }: ImgViewerProps) {
     const init = "placeholder.jpg";
     const [url, setUrl] = useState(init);
     const [err, setErr] = useState(null);
@@ -17,20 +19,17 @@ export default function ImgViewer({ assetKey, altAssetKey }: ImgViewerProps) {
             return;
         }
         const fun = async () => {
-            const tmp = await Storage.get(assetKey, {
-                download: false,
-                expires: 10,
-            });
+            const tmp = await getPresignedKey(assetId, databaseId, assetKey);
             setUrl(tmp);
         };
         fun();
-    }, [assetKey, url]);
+    }, [assetId, assetKey, databaseId, url]);
 
     const fallback = (error: any) => {
         console.log("handling image load err", error);
         if (err === null) {
             setErr(error);
-            Storage.get(altAssetKey, { download: false, expires: 10 }).then(setUrl);
+            getPresignedKey(assetId, databaseId, altAssetKey).then(setUrl);
         }
     };
     return (

--- a/web/src/components/viewers/ModelViewer.js
+++ b/web/src/components/viewers/ModelViewer.js
@@ -4,21 +4,17 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Storage } from "aws-amplify";
 import * as OV from "online-3d-viewer";
+import { getPresignedKey } from "../../common/auth/s3";
 
 export default function ModelViewer(props) {
     const engineElement = useRef(null);
-    const { assetKey } = props;
+    const { assetId, databaseId, assetKey } = props;
     const [loaded, setLoaded] = useState(false);
 
     useEffect(() => {
-        let config = {
-            download: false,
-            expires: 1000,
-        };
         const loadAsset = async () => {
-            await Storage.get(assetKey, config).then((remoteFileUrl) => {
+            await getPresignedKey(assetId, databaseId, assetKey).then((remoteFileUrl) => {
                 engineElement.current.setAttribute("model", remoteFileUrl);
                 setTimeout(() => {
                     let parentDiv = engineElement.current;
@@ -35,7 +31,7 @@ export default function ModelViewer(props) {
             loadAsset();
             setLoaded(true);
         }
-    }, [loaded, assetKey]);
+    }, [loaded, assetKey, assetId, databaseId]);
 
     return (
         <div

--- a/web/src/components/viewers/ThreeDimensionalPlotter.js
+++ b/web/src/components/viewers/ThreeDimensionalPlotter.js
@@ -7,7 +7,6 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { Storage } from "aws-amplify";
 import {
     Engine,
     Scene,
@@ -30,6 +29,7 @@ import "babylonjs-loaders";
 import { readRemoteFile } from "react-papaparse";
 import FCS from "fcs";
 import arrayBufferToBuffer from "arraybuffer-to-buffer";
+import { getPresignedKey } from "../../common/auth/s3";
 
 let scatterPlot = {};
 let points = [];
@@ -375,7 +375,15 @@ const readCsvFile = (remoteFileUrl, render) => {
 
 export default function ThreeDimensionalPlotter(props) {
     const reactCanvas = useRef(null);
-    const { assetKey, engineOptions, adaptToDeviceRatio, sceneOptions, ...rest } = props;
+    const {
+        assetId,
+        databaseId,
+        assetKey,
+        engineOptions,
+        adaptToDeviceRatio,
+        sceneOptions,
+        ...rest
+    } = props;
     const [loaded, setLoaded] = useState(false);
     const antialias = true;
 
@@ -543,7 +551,7 @@ export default function ThreeDimensionalPlotter(props) {
         };
         const loadAsset = async () => {
             points = [];
-            await Storage.get(assetKey, config).then((remoteFileUrl) => {
+            await getPresignedKey(assetId, databaseId, assetKey).then((remoteFileUrl) => {
                 if (assetKey.indexOf(".fcs") !== -1) {
                     try {
                         readFcsFile(remoteFileUrl, render);

--- a/web/src/pages/AssetUpload/onSubmit.ts
+++ b/web/src/pages/AssetUpload/onSubmit.ts
@@ -11,7 +11,8 @@ import { Metadata, MetadataApi } from "../../components/single/Metadata";
 import { AssetDetail } from "../AssetUpload";
 import { generateUUID } from "../../common/utils/utils";
 import { FileUploadTableItem } from "./FileUploadTable";
-import { getUploadTaskPromise } from "../../common/auth/s3";
+import getUploadTaskPromise from "../../common/s3/uploadtaskpromise";
+import { GetCredentials } from "../../common/s3/credentials";
 
 export type ExecStatusType = Record<string, StatusIndicatorProps.Type>;
 
@@ -62,7 +63,7 @@ export function createAssetUploadPromises(
     isMultiFile: boolean,
     files: FileUploadTableItem[],
     keyPrefix: string,
-    metadata: { [k: string]: string },
+    metadata: { [k: string]: string } & GetCredentials,
     moveToQueued: (index: number) => void,
     progressCallback: (index: number, progress: ProgressCallbackArgs) => void,
     completeCallback: (index: number, event: any) => void,

--- a/web/src/pages/search/SearchPage.tsx
+++ b/web/src/pages/search/SearchPage.tsx
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import React, { Dispatch, ReducerAction, useEffect, useReducer, useState } from "react";
 import SearchPropertyFilter, { changeFilter, search } from "./SearchPropertyFilter";
 import Container from "@cloudscape-design/components/container";

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -8,6 +8,7 @@ import { Route, Routes } from "react-router-dom";
 import AppLayout from "@cloudscape-design/components/app-layout";
 import { Navigation } from "./layout/Navigation";
 import LandingPage from "./pages/LandingPage";
+import Spinner from "@cloudscape-design/components/spinner";
 
 const Databases = React.lazy(() => import("./pages/Databases"));
 const SearchPage = React.lazy(() => import("./pages/search/SearchPage"));
@@ -139,6 +140,23 @@ interface AppRoutesProps {
     user: any;
 }
 
+function CenterSpinner() {
+    return (
+        <div
+            aria-live="polite"
+            aria-label="Loading page content."
+            style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                height: "100%",
+            }}
+        >
+            <Spinner size="large" />
+        </div>
+    );
+}
+
 export const AppRoutes = ({ navigationOpen, setNavigationOpen, user }: AppRoutesProps) => {
     const buildRoute = (routeOptions: RouteOption, i: number = 0) => {
         const { path, active, Page } = routeOptions;
@@ -150,7 +168,7 @@ export const AppRoutes = ({ navigationOpen, setNavigationOpen, user }: AppRoutes
                     <AppLayout
                         disableContentPaddings={navigationOpen}
                         content={
-                            <Suspense fallback={<div />}>
+                            <Suspense fallback={<CenterSpinner />}>
                                 <Page />
                             </Suspense>
                         }

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -3,25 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react";
+import React, { Suspense } from "react";
 import { Route, Routes } from "react-router-dom";
 import AppLayout from "@cloudscape-design/components/app-layout";
-import LandingPage from "./pages/LandingPage";
-import SearchPage from "./pages/search/SearchPage";
 import { Navigation } from "./layout/Navigation";
-import Databases from "./pages/Databases";
-import Assets from "./pages/Assets";
-import Comments from "./pages/Comments/Comments";
-import AssetUploadPage from "./pages/AssetUpload";
-import ViewAsset from "./components/single/ViewAsset";
-import Pipelines from "./pages/Pipelines";
-import ViewPipeline from "./components/single/ViewPipeline";
-import Workflows from "./pages/Workflows";
-import CreateUpdateWorkflow from "./components/createupdate/CreateUpdateWorkflow";
-import Constraints from "./pages/auth/Constraints";
-import FinishUploadsPage from "./pages/FinishUploads";
-import MetadataSchema from "./pages/MetadataSchema";
-import ViewFile from "./components/single/ViewFile";
+import LandingPage from "./pages/LandingPage";
+
+const Databases = React.lazy(() => import("./pages/Databases"));
+const SearchPage = React.lazy(() => import("./pages/search/SearchPage"));
+const Comments = React.lazy(() => import("./pages/Comments/Comments"));
+const AssetUploadPage = React.lazy(() => import("./pages/AssetUpload"));
+const ViewAsset = React.lazy(() => import("./components/single/ViewAsset"));
+const Pipelines = React.lazy(() => import("./pages/Pipelines"));
+const ViewPipeline = React.lazy(() => import("./components/single/ViewPipeline"));
+const Workflows = React.lazy(() => import("./pages/Workflows"));
+const CreateUpdateWorkflow = React.lazy(
+    () => import("./components/createupdate/CreateUpdateWorkflow")
+);
+const Constraints = React.lazy(() => import("./pages/auth/Constraints"));
+const FinishUploadsPage = React.lazy(() => import("./pages/FinishUploads"));
+const MetadataSchema = React.lazy(() => import("./pages/MetadataSchema"));
+const ViewFile = React.lazy(() => import("./components/single/ViewFile"));
 
 interface RouteOption {
     path: string;
@@ -147,7 +149,11 @@ export const AppRoutes = ({ navigationOpen, setNavigationOpen, user }: AppRoutes
                 element={
                     <AppLayout
                         disableContentPaddings={navigationOpen}
-                        content={<Page />}
+                        content={
+                            <Suspense fallback={<div />}>
+                                <Page />
+                            </Suspense>
+                        }
                         navigation={<Navigation activeHref={active} user={user} />}
                         navigationOpen={navigationOpen}
                         onNavigationChange={({ detail }) => setNavigationOpen(detail.open)}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
 "@adobe/css-tools@^4.0.1":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.2.0.tgz#e1a84fca468f4b337816fcb7f0964beb620ba855"
-  integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
+  integrity "sha1-q/zLjKeAdaK2GHNFwmJDwaCELyg= sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg=="
 
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -505,14 +505,6 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/chunked-blob-reader-native@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.310.0.tgz#98d43a6213557835b3bbb0cd2ee0a4e2088e916a"
-  integrity sha512-RuhyUY9hCd6KWA2DMF/U6rilYLLRYrDY6e0lq3Of1yzSRFxi4bk9ZMCF0mxf/9ppsB5eudUjrOypYgm6Axt3zw==
-  dependencies:
-    "@aws-sdk/util-base64" "3.310.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/chunked-blob-reader-native@3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.6.1.tgz#21c2c8773c3cd8403c2a953fd0e9e4f69c120214"
@@ -520,13 +512,6 @@
   dependencies:
     "@aws-sdk/util-base64-browser" "3.6.1"
     tslib "^1.8.0"
-
-"@aws-sdk/chunked-blob-reader@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz#2ada1b024a2745c2fe7e869606fab781325f981e"
-  integrity sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==
-  dependencies:
-    tslib "^2.5.0"
 
 "@aws-sdk/chunked-blob-reader@3.6.1":
   version "3.6.1"
@@ -977,103 +962,64 @@
     fast-xml-parser "4.2.5"
     tslib "^2.0.0"
 
-"@aws-sdk/client-s3@^3.338.0":
-  version "3.367.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.367.0.tgz#924e45ee358bf1449c07473d98a7e11057c9d76e"
-  integrity sha512-E9onOs03zHDo/ytjEooCbSbYNUvvvOc5dK7oNEQ9s5cpGjiY2ojQieMg7x+Uz7FbAslIEsABXliYe2Xib+N7Ug==
+"@aws-sdk/client-s3@^3.400.0":
+  version "3.400.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.400.0.tgz#579dfa12c93bf12f0d8654fcbfe36f7989209a4d"
+  integrity sha512-lnv0pb79Czl8fCMs/z7yM56LvoKTri1I4jX/V33trHMFKPQDoy8i24wxG8+TZl3MUmnUyoQS7tlukh7IFkii1Q==
   dependencies:
     "@aws-crypto/sha1-browser" "3.0.0"
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/client-sts" "3.363.0"
-    "@aws-sdk/credential-provider-node" "3.363.0"
-    "@aws-sdk/hash-blob-browser" "3.367.0"
-    "@aws-sdk/hash-stream-node" "3.357.0"
-    "@aws-sdk/md5-js" "3.357.0"
-    "@aws-sdk/middleware-bucket-endpoint" "3.363.0"
-    "@aws-sdk/middleware-expect-continue" "3.363.0"
-    "@aws-sdk/middleware-flexible-checksums" "3.363.0"
-    "@aws-sdk/middleware-host-header" "3.363.0"
-    "@aws-sdk/middleware-location-constraint" "3.363.0"
-    "@aws-sdk/middleware-logger" "3.363.0"
-    "@aws-sdk/middleware-recursion-detection" "3.363.0"
-    "@aws-sdk/middleware-sdk-s3" "3.363.0"
-    "@aws-sdk/middleware-signing" "3.363.0"
-    "@aws-sdk/middleware-ssec" "3.363.0"
-    "@aws-sdk/middleware-user-agent" "3.363.0"
-    "@aws-sdk/signature-v4-multi-region" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-endpoints" "3.357.0"
-    "@aws-sdk/util-user-agent-browser" "3.363.0"
-    "@aws-sdk/util-user-agent-node" "3.363.0"
+    "@aws-sdk/client-sts" "3.398.0"
+    "@aws-sdk/credential-provider-node" "3.398.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.398.0"
+    "@aws-sdk/middleware-expect-continue" "3.398.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.400.0"
+    "@aws-sdk/middleware-host-header" "3.398.0"
+    "@aws-sdk/middleware-location-constraint" "3.398.0"
+    "@aws-sdk/middleware-logger" "3.398.0"
+    "@aws-sdk/middleware-recursion-detection" "3.398.0"
+    "@aws-sdk/middleware-sdk-s3" "3.398.0"
+    "@aws-sdk/middleware-signing" "3.398.0"
+    "@aws-sdk/middleware-ssec" "3.398.0"
+    "@aws-sdk/middleware-user-agent" "3.398.0"
+    "@aws-sdk/signature-v4-multi-region" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@aws-sdk/util-user-agent-browser" "3.398.0"
+    "@aws-sdk/util-user-agent-node" "3.398.0"
     "@aws-sdk/xml-builder" "3.310.0"
-    "@smithy/config-resolver" "^1.0.1"
-    "@smithy/eventstream-serde-browser" "^1.0.1"
-    "@smithy/eventstream-serde-config-resolver" "^1.0.1"
-    "@smithy/eventstream-serde-node" "^1.0.1"
-    "@smithy/fetch-http-handler" "^1.0.1"
-    "@smithy/hash-node" "^1.0.1"
-    "@smithy/invalid-dependency" "^1.0.1"
-    "@smithy/middleware-content-length" "^1.0.1"
-    "@smithy/middleware-endpoint" "^1.0.1"
-    "@smithy/middleware-retry" "^1.0.2"
-    "@smithy/middleware-serde" "^1.0.1"
-    "@smithy/middleware-stack" "^1.0.1"
-    "@smithy/node-config-provider" "^1.0.1"
-    "@smithy/node-http-handler" "^1.0.2"
-    "@smithy/protocol-http" "^1.0.1"
-    "@smithy/smithy-client" "^1.0.3"
-    "@smithy/types" "^1.0.0"
-    "@smithy/url-parser" "^1.0.1"
-    "@smithy/util-base64" "^1.0.1"
-    "@smithy/util-body-length-browser" "^1.0.1"
-    "@smithy/util-body-length-node" "^1.0.1"
-    "@smithy/util-defaults-mode-browser" "^1.0.1"
-    "@smithy/util-defaults-mode-node" "^1.0.1"
-    "@smithy/util-retry" "^1.0.2"
-    "@smithy/util-stream" "^1.0.1"
-    "@smithy/util-utf8" "^1.0.1"
-    "@smithy/util-waiter" "^1.0.1"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/eventstream-serde-browser" "^2.0.5"
+    "@smithy/eventstream-serde-config-resolver" "^2.0.5"
+    "@smithy/eventstream-serde-node" "^2.0.5"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/hash-blob-browser" "^2.0.5"
+    "@smithy/hash-node" "^2.0.5"
+    "@smithy/hash-stream-node" "^2.0.5"
+    "@smithy/invalid-dependency" "^2.0.5"
+    "@smithy/md5-js" "^2.0.5"
+    "@smithy/middleware-content-length" "^2.0.5"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/middleware-retry" "^2.0.5"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.5"
+    "@smithy/util-defaults-mode-node" "^2.0.5"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-stream" "^2.0.5"
+    "@smithy/util-utf8" "^2.0.0"
+    "@smithy/util-waiter" "^2.0.5"
     fast-xml-parser "4.2.5"
-    tslib "^2.5.0"
-
-"@aws-sdk/client-sso-oidc@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.363.0.tgz#71240d729a0847fd5a7aaac09ed5a3a07c3666cf"
-  integrity sha512-V3Ebiq/zNtDS/O92HUWGBa7MY59RYSsqWd+E0XrXv6VYTA00RlMTbNcseivNgp2UghOgB9a20Nkz6EqAeIN+RQ==
-  dependencies:
-    "@aws-crypto/sha256-browser" "3.0.0"
-    "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/middleware-host-header" "3.363.0"
-    "@aws-sdk/middleware-logger" "3.363.0"
-    "@aws-sdk/middleware-recursion-detection" "3.363.0"
-    "@aws-sdk/middleware-user-agent" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-endpoints" "3.357.0"
-    "@aws-sdk/util-user-agent-browser" "3.363.0"
-    "@aws-sdk/util-user-agent-node" "3.363.0"
-    "@smithy/config-resolver" "^1.0.1"
-    "@smithy/fetch-http-handler" "^1.0.1"
-    "@smithy/hash-node" "^1.0.1"
-    "@smithy/invalid-dependency" "^1.0.1"
-    "@smithy/middleware-content-length" "^1.0.1"
-    "@smithy/middleware-endpoint" "^1.0.1"
-    "@smithy/middleware-retry" "^1.0.2"
-    "@smithy/middleware-serde" "^1.0.1"
-    "@smithy/middleware-stack" "^1.0.1"
-    "@smithy/node-config-provider" "^1.0.1"
-    "@smithy/node-http-handler" "^1.0.2"
-    "@smithy/protocol-http" "^1.0.1"
-    "@smithy/smithy-client" "^1.0.3"
-    "@smithy/types" "^1.0.0"
-    "@smithy/url-parser" "^1.0.1"
-    "@smithy/util-base64" "^1.0.1"
-    "@smithy/util-body-length-browser" "^1.0.1"
-    "@smithy/util-body-length-node" "^1.0.1"
-    "@smithy/util-defaults-mode-browser" "^1.0.1"
-    "@smithy/util-defaults-mode-node" "^1.0.1"
-    "@smithy/util-retry" "^1.0.2"
-    "@smithy/util-utf8" "^1.0.1"
     tslib "^2.5.0"
 
 "@aws-sdk/client-sso@3.186.0":
@@ -1113,43 +1059,43 @@
     "@aws-sdk/util-utf8-node" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sso@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.363.0.tgz#b1939ee6769cf208f1dd4fbfa924c223da9d60ec"
-  integrity sha512-PZ+HfKSgS4hlMnJzG+Ev8/mgHd/b/ETlJWPSWjC/f2NwVoBQkBnqHjdyEx7QjF6nksJozcVh5Q+kkYLKc/QwBQ==
+"@aws-sdk/client-sso@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.398.0.tgz#68ce0a4d359794b629e5a7efe43a24ed9b52211e"
+  integrity sha512-CygL0jhfibw4kmWXG/3sfZMFNjcXo66XUuPC4BqZBk8Rj5vFoxp1vZeMkDLzTIk97Nvo5J5Bh+QnXKhub6AckQ==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/middleware-host-header" "3.363.0"
-    "@aws-sdk/middleware-logger" "3.363.0"
-    "@aws-sdk/middleware-recursion-detection" "3.363.0"
-    "@aws-sdk/middleware-user-agent" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-endpoints" "3.357.0"
-    "@aws-sdk/util-user-agent-browser" "3.363.0"
-    "@aws-sdk/util-user-agent-node" "3.363.0"
-    "@smithy/config-resolver" "^1.0.1"
-    "@smithy/fetch-http-handler" "^1.0.1"
-    "@smithy/hash-node" "^1.0.1"
-    "@smithy/invalid-dependency" "^1.0.1"
-    "@smithy/middleware-content-length" "^1.0.1"
-    "@smithy/middleware-endpoint" "^1.0.1"
-    "@smithy/middleware-retry" "^1.0.2"
-    "@smithy/middleware-serde" "^1.0.1"
-    "@smithy/middleware-stack" "^1.0.1"
-    "@smithy/node-config-provider" "^1.0.1"
-    "@smithy/node-http-handler" "^1.0.2"
-    "@smithy/protocol-http" "^1.0.1"
-    "@smithy/smithy-client" "^1.0.3"
-    "@smithy/types" "^1.0.0"
-    "@smithy/url-parser" "^1.0.1"
-    "@smithy/util-base64" "^1.0.1"
-    "@smithy/util-body-length-browser" "^1.0.1"
-    "@smithy/util-body-length-node" "^1.0.1"
-    "@smithy/util-defaults-mode-browser" "^1.0.1"
-    "@smithy/util-defaults-mode-node" "^1.0.1"
-    "@smithy/util-retry" "^1.0.2"
-    "@smithy/util-utf8" "^1.0.1"
+    "@aws-sdk/middleware-host-header" "3.398.0"
+    "@aws-sdk/middleware-logger" "3.398.0"
+    "@aws-sdk/middleware-recursion-detection" "3.398.0"
+    "@aws-sdk/middleware-user-agent" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@aws-sdk/util-user-agent-browser" "3.398.0"
+    "@aws-sdk/util-user-agent-node" "3.398.0"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/hash-node" "^2.0.5"
+    "@smithy/invalid-dependency" "^2.0.5"
+    "@smithy/middleware-content-length" "^2.0.5"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/middleware-retry" "^2.0.5"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.5"
+    "@smithy/util-defaults-mode-node" "^2.0.5"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/client-sts@3.186.3":
@@ -1194,46 +1140,46 @@
     fast-xml-parser "4.2.5"
     tslib "^2.3.1"
 
-"@aws-sdk/client-sts@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.363.0.tgz#c02b3cf3bd2ef9d54195323370db964cd1df4711"
-  integrity sha512-0jj14WvBPJQ8xr72cL0mhlmQ90tF0O0wqXwSbtog6PsC8+KDE6Yf+WsxsumyI8E5O8u3eYijBL+KdqG07F/y/w==
+"@aws-sdk/client-sts@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.398.0.tgz#8c569760d05b9fe663f82fc092d39b093096f7cc"
+  integrity sha512-/3Pa9wLMvBZipKraq3AtbmTfXW6q9kyvhwOno64f1Fz7kFb8ijQFMGoATS70B2pGEZTlxkUqJFWDiisT6Q6dFg==
   dependencies:
     "@aws-crypto/sha256-browser" "3.0.0"
     "@aws-crypto/sha256-js" "3.0.0"
-    "@aws-sdk/credential-provider-node" "3.363.0"
-    "@aws-sdk/middleware-host-header" "3.363.0"
-    "@aws-sdk/middleware-logger" "3.363.0"
-    "@aws-sdk/middleware-recursion-detection" "3.363.0"
-    "@aws-sdk/middleware-sdk-sts" "3.363.0"
-    "@aws-sdk/middleware-signing" "3.363.0"
-    "@aws-sdk/middleware-user-agent" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-endpoints" "3.357.0"
-    "@aws-sdk/util-user-agent-browser" "3.363.0"
-    "@aws-sdk/util-user-agent-node" "3.363.0"
-    "@smithy/config-resolver" "^1.0.1"
-    "@smithy/fetch-http-handler" "^1.0.1"
-    "@smithy/hash-node" "^1.0.1"
-    "@smithy/invalid-dependency" "^1.0.1"
-    "@smithy/middleware-content-length" "^1.0.1"
-    "@smithy/middleware-endpoint" "^1.0.1"
-    "@smithy/middleware-retry" "^1.0.1"
-    "@smithy/middleware-serde" "^1.0.1"
-    "@smithy/middleware-stack" "^1.0.1"
-    "@smithy/node-config-provider" "^1.0.1"
-    "@smithy/node-http-handler" "^1.0.1"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/smithy-client" "^1.0.2"
-    "@smithy/types" "^1.1.0"
-    "@smithy/url-parser" "^1.0.1"
-    "@smithy/util-base64" "^1.0.1"
-    "@smithy/util-body-length-browser" "^1.0.1"
-    "@smithy/util-body-length-node" "^1.0.1"
-    "@smithy/util-defaults-mode-browser" "^1.0.1"
-    "@smithy/util-defaults-mode-node" "^1.0.1"
-    "@smithy/util-retry" "^1.0.1"
-    "@smithy/util-utf8" "^1.0.1"
+    "@aws-sdk/credential-provider-node" "3.398.0"
+    "@aws-sdk/middleware-host-header" "3.398.0"
+    "@aws-sdk/middleware-logger" "3.398.0"
+    "@aws-sdk/middleware-recursion-detection" "3.398.0"
+    "@aws-sdk/middleware-sdk-sts" "3.398.0"
+    "@aws-sdk/middleware-signing" "3.398.0"
+    "@aws-sdk/middleware-user-agent" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@aws-sdk/util-user-agent-browser" "3.398.0"
+    "@aws-sdk/util-user-agent-node" "3.398.0"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/hash-node" "^2.0.5"
+    "@smithy/invalid-dependency" "^2.0.5"
+    "@smithy/middleware-content-length" "^2.0.5"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/middleware-retry" "^2.0.5"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.5"
+    "@smithy/util-defaults-mode-node" "^2.0.5"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
     fast-xml-parser "4.2.5"
     tslib "^2.5.0"
 
@@ -1341,14 +1287,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-env@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.363.0.tgz#5b8471a243cdb54696ecae99ad4cc1c48d687657"
-  integrity sha512-VAQ3zITT2Q0acht0HezouYnMFKZ2vIOa20X4zQA3WI0HfaP4D6ga6KaenbDcb/4VFiqfqiRHfdyXHP0ThcDRMA==
+"@aws-sdk/credential-provider-env@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.398.0.tgz#28d0d4d2de85dd35fdf83298191ea495da8f8646"
+  integrity sha512-Z8Yj5z7FroAsR6UVML+XUdlpoqEe9Dnle8c2h8/xWwIC2feTfIBhjLhRVxfbpbM1pLgBSNEcZ7U8fwq5l7ESVQ==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/credential-provider-env@3.6.1":
@@ -1394,20 +1340,20 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-ini@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.363.0.tgz#e77e65e1ffc7c736aa724ebdf038e99dca57a87b"
-  integrity sha512-ZYN+INoqyX5FVC3rqUxB6O8nOWkr0gHRRBm1suoOlmuFJ/WSlW/uUGthRBY5x1AQQnBF8cpdlxZzGHd41lFVNw==
+"@aws-sdk/credential-provider-ini@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.398.0.tgz#723264d8d8adb01963fdfe9fe9005aa20def3a56"
+  integrity sha512-AsK1lStK3nB9Cn6S6ODb1ktGh7SRejsNVQVKX3t5d3tgOaX+aX1Iwy8FzM/ZEN8uCloeRifUGIY9uQFygg5mSw==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.363.0"
-    "@aws-sdk/credential-provider-process" "3.363.0"
-    "@aws-sdk/credential-provider-sso" "3.363.0"
-    "@aws-sdk/credential-provider-web-identity" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/credential-provider-imds" "^1.0.1"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/shared-ini-file-loader" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/credential-provider-env" "3.398.0"
+    "@aws-sdk/credential-provider-process" "3.398.0"
+    "@aws-sdk/credential-provider-sso" "3.398.0"
+    "@aws-sdk/credential-provider-web-identity" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/credential-provider-ini@3.6.1":
@@ -1436,21 +1382,21 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-node@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.363.0.tgz#70815b3c8bc98d9afd148b851c8fdae9ce11fcd6"
-  integrity sha512-C1qXFIN2yMxD6pGgug0vR1UhScOki6VqdzuBHzXZAGu7MOjvgHNdscEcb3CpWnITHaPL2ztkiw75T1sZ7oIgQg==
+"@aws-sdk/credential-provider-node@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.398.0.tgz#afc6e6417b071a5a5b242329fd9c80aacba40f7d"
+  integrity sha512-odmI/DSKfuWUYeDnGTCEHBbC8/MwnF6yEq874zl6+owoVv0ZsYP8qBHfiJkYqrwg7wQ7Pi40sSAPC1rhesGwzg==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.363.0"
-    "@aws-sdk/credential-provider-ini" "3.363.0"
-    "@aws-sdk/credential-provider-process" "3.363.0"
-    "@aws-sdk/credential-provider-sso" "3.363.0"
-    "@aws-sdk/credential-provider-web-identity" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/credential-provider-imds" "^1.0.1"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/shared-ini-file-loader" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/credential-provider-env" "3.398.0"
+    "@aws-sdk/credential-provider-ini" "3.398.0"
+    "@aws-sdk/credential-provider-process" "3.398.0"
+    "@aws-sdk/credential-provider-sso" "3.398.0"
+    "@aws-sdk/credential-provider-web-identity" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/credential-provider-imds" "^2.0.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/credential-provider-node@3.6.1":
@@ -1477,15 +1423,15 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-process@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.363.0.tgz#08608f6da246084f9b20481ac0de17f04ae54b4d"
-  integrity sha512-fOKAINU7Rtj2T8pP13GdCt+u0Ml3gYynp8ki+1jMZIQ+Ju/MdDOqZpKMFKicMn3Z1ttUOgqr+grUdus6z8ceBQ==
+"@aws-sdk/credential-provider-process@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.398.0.tgz#bae46e14bcb664371d33926118bad61866184317"
+  integrity sha512-WrkBL1W7TXN508PA9wRXPFtzmGpVSW98gDaHEaa8GolAPHMPa5t2QcC/z/cFpglzrcVv8SA277zu9Z8tELdZhg==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/shared-ini-file-loader" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/credential-provider-process@3.6.1":
@@ -1510,17 +1456,17 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-sso@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.363.0.tgz#949190c9ea510d9772aef9c61345575f4b40b44d"
-  integrity sha512-5RUZ5oM0lwZSo3EehT0dXggOjgtxFogpT3cZvoLGtIwrPBvm8jOQPXQUlaqCj10ThF1sYltEyukz/ovtDwYGew==
+"@aws-sdk/credential-provider-sso@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.398.0.tgz#b8a094e5e62cea233d77e27c8b7e2ce65e9f7559"
+  integrity sha512-2Dl35587xbnzR/GGZqA2MnFs8+kS4wbHQO9BioU0okA+8NRueohNMdrdQmQDdSNK4BfIpFspiZmFkXFNyEAfgw==
   dependencies:
-    "@aws-sdk/client-sso" "3.363.0"
-    "@aws-sdk/token-providers" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/shared-ini-file-loader" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/client-sso" "3.398.0"
+    "@aws-sdk/token-providers" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/credential-provider-web-identity@3.186.0":
@@ -1532,14 +1478,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/credential-provider-web-identity@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.363.0.tgz#a5312519126ff7c3fea56ffefa0e51ef9383663c"
-  integrity sha512-Z6w7fjgy79pAax580wdixbStQw10xfyZ+hOYLcPudoYFKjoNx0NQBejg5SwBzCF/HQL23Ksm9kDfbXDX9fkPhA==
+"@aws-sdk/credential-provider-web-identity@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.398.0.tgz#0396a34bf9d2e4b48530c2f899cbb4101b592db8"
+  integrity sha512-iG3905Alv9pINbQ8/MIsshgqYMbWx+NDQWpxbIW3W0MkSH3iAqdVpSCteYidYX9G/jv2Um1nW3y360ib20bvNg==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/eventstream-codec@3.186.0":
@@ -1665,16 +1611,6 @@
     "@aws-sdk/util-base64-browser" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/hash-blob-browser@3.367.0":
-  version "3.367.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.367.0.tgz#1ec6732eb849c83ab96049edcd6479ddec17c4c8"
-  integrity sha512-RhkpXceqQP5UF0eGvLVRSM/gJI8rUdgThAFLPlM5cYRPtIoeDddTTNk0BEf8GzetXTyzx3TEe1Z5tEjbb0pMuA==
-  dependencies:
-    "@aws-sdk/chunked-blob-reader" "3.310.0"
-    "@aws-sdk/chunked-blob-reader-native" "3.310.0"
-    "@aws-sdk/types" "3.357.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/hash-blob-browser@3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.6.1.tgz#f44a1857b75769e21cd6091211171135e03531e6"
@@ -1702,15 +1638,6 @@
     "@aws-sdk/types" "3.6.1"
     "@aws-sdk/util-buffer-from" "3.6.1"
     tslib "^1.8.0"
-
-"@aws-sdk/hash-stream-node@3.357.0":
-  version "3.357.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-3.357.0.tgz#a78c6d1ae1c78cb52854311bad50988e8fc12142"
-  integrity sha512-KZjN1VAw1KHNp+xKVOWBGS+MpaYQTjZFD5f+7QQqW4TfbAkFFwIAEYIHq5Q8Gw+jVh0h61OrV/LyW3J2PVzc+w==
-  dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-utf8" "3.310.0"
-    tslib "^2.5.0"
 
 "@aws-sdk/hash-stream-node@3.6.1":
   version "3.6.1"
@@ -1743,13 +1670,6 @@
   dependencies:
     tslib "^2.3.1"
 
-"@aws-sdk/is-array-buffer@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz#f87a79f1b858c88744f07e8d8d0a791df204017e"
-  integrity sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==
-  dependencies:
-    tslib "^2.5.0"
-
 "@aws-sdk/is-array-buffer@3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.6.1.tgz#96df5d64b2d599947f81b164d5d92623f85c659c"
@@ -1757,13 +1677,17 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/md5-js@3.357.0":
-  version "3.357.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/md5-js/-/md5-js-3.357.0.tgz#61853f562e71af0ec58aeede7883de122177ed55"
-  integrity sha512-to42sFAL7KgV/X9X40LLfEaNMHMGQL6/7mPMVCL/W2BZf3zw5OTl3lAaNyjXA+gO5Uo4lFEiQKAQVKNbr8b8Nw==
+"@aws-sdk/lib-storage@^3.400.0":
+  version "3.400.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.400.0.tgz#eea66d08f15174b3c8dd8d0cc2de4c649988db8a"
+  integrity sha512-i8AF0KHSHRuqz/KDx+rdKXWlQwIDgtIPLdUb4Srtu0afq6ehgsx62EazT4oNXkTp4WtVjbaTdXR8TcDXCCzw6g==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-utf8" "3.310.0"
+    "@smithy/abort-controller" "^2.0.1"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    buffer "5.6.0"
+    events "3.3.0"
+    stream-browserify "3.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/md5-js@3.6.1":
@@ -1785,16 +1709,16 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-bucket-endpoint@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.363.0.tgz#6c9b2dda20eaaf9171b7f2c4faff3b34b4331522"
-  integrity sha512-kR8+0X50zslpzRW29q4JbpPMadE1z39ZfGwPaBLKpoWvSGt4x+75FaoK71TH7urPPoFyD2Y+XKGA6YRYTUNHSQ==
+"@aws-sdk/middleware-bucket-endpoint@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.398.0.tgz#1cff84e1f71043346277f3c1a6268763c631a984"
+  integrity sha512-+iDHiRofK/vIY94RWAXkSnR4rBPzc2dPHmLp+FDKywq1y708H9W7TOT37dpn+KSFeO4k2FfddFjzWBHsaeakCA==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
+    "@aws-sdk/types" "3.398.0"
     "@aws-sdk/util-arn-parser" "3.310.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
-    "@smithy/util-config-provider" "^1.0.1"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-config-provider" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-bucket-endpoint@3.6.1":
@@ -1834,14 +1758,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-expect-continue@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.363.0.tgz#125356f3685e14eaa8816383bbf5f3de05dd856e"
-  integrity sha512-I88xneZp6jRwySmIl9uI7eZCcTsqRVnTDfUr1JiXt7zonqNNm80PVYMs6pwaw7t97ec1AQJcsONjuXZyCMnu5g==
+"@aws-sdk/middleware-expect-continue@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.398.0.tgz#a43cbe0a5b339238f5f307c69798da8f69e5c111"
+  integrity sha512-d6he+Qqwh1yqml9duXSv5iKJ2lS0PVrF2UEsVew2GFxfUif0E/davTZJjvWtnelbuIGcTP+wDKVVjLwBN2sN/g==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-expect-continue@3.6.1":
@@ -1854,18 +1778,18 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-flexible-checksums@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.363.0.tgz#99cd3e09183768ac378eae5c5f4e54189147921d"
-  integrity sha512-FBYmrMRX01uNximNN0WLgpf97GN4xNTLaKsDlkjYRWKJ+J97ICkvLG0FcSu7+SNCpCdJJBeQ5tRVOPVpUu6nmA==
+"@aws-sdk/middleware-flexible-checksums@3.400.0":
+  version "3.400.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.400.0.tgz#f3cb1e9f42968d2177b583a83e5027b4d3f70e67"
+  integrity sha512-lpsumd5/G+eAMTr61h/cJQZ8+i+xzC6OG3bvUcbRHqcjN49XgeNLcPfYcr6Rzf0QHxmuCN4te/4XGU3Fif2YVA==
   dependencies:
     "@aws-crypto/crc32" "3.0.0"
     "@aws-crypto/crc32c" "3.0.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/is-array-buffer" "^1.0.1"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
-    "@smithy/util-utf8" "^1.0.1"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/is-array-buffer" "^2.0.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-header-default@3.6.1":
@@ -1886,14 +1810,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-host-header@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.363.0.tgz#3fc25569c1fdbb29ee7b95690d222743b9791210"
-  integrity sha512-FobpclDCf5Y1ueyJDmb9MqguAdPssNMlnqWQpujhYVABq69KHu73fSCWSauFPUrw7YOpV8kG1uagDF0POSxHzA==
+"@aws-sdk/middleware-host-header@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.398.0.tgz#4e5eeaa8ead96237e70cb6930dfb813a9c21ae8c"
+  integrity sha512-m+5laWdBaxIZK2ko0OwcCHJZJ5V1MgEIt8QVQ3k4/kOkN9ICjevOYmba751pHoTnbOYB7zQd6D2OT3EYEEsUcA==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-host-header@3.6.1":
@@ -1905,13 +1829,13 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-location-constraint@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.363.0.tgz#48c8a16698d7678578a5f06e0eb7f8118ec86f82"
-  integrity sha512-piNzpNNI/fChSGOZxcq/2msN2qFUSEAbhqs91zbcpv8CEPekVLc4W9laXCG764BEMyfG97ZU8MtzwHeMhELhBA==
+"@aws-sdk/middleware-location-constraint@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.398.0.tgz#ec7d046401d1f547d8dd55bf1c94ed067b10224b"
+  integrity sha512-it+olJf1Lf2bmH8OL/N1jMOFB0zEVYs4rIzgFrluTRCuPatRuDi4LsXS8zqYxkBa05JE8JmqwW5gCzAmWyLLqw==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-location-constraint@3.6.1":
@@ -1930,13 +1854,13 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-logger@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.363.0.tgz#64ebef9910802f9437cae8900e8825ca5141c9ed"
-  integrity sha512-SSGgthScYnFGTOw8EzbkvquqweFmvn7uJihkpFekbtBNGC/jGOGO+8ziHjTQ8t/iI/YKubEwv+LMi0f77HKSEg==
+"@aws-sdk/middleware-logger@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.398.0.tgz#1f336c329861c2aa7cc267d84ef41e74e98b1502"
+  integrity sha512-CiJjW+FL12elS6Pn7/UVjVK8HWHhXMfvHZvOwx/Qkpy340sIhkuzOO6fZEruECDTZhl2Wqn81XdJ1ZQ4pRKpCg==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-logger@3.6.1":
@@ -1956,14 +1880,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-recursion-detection@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.363.0.tgz#bd8b8010f5be5d7e90a97bf9e55a7980289b1600"
-  integrity sha512-MWD/57QgI/N7fG8rtzDTUdSqNpYohQfgj9XCFAoVeI/bU4usrkOrew43L4smJG4XrDxlNT8lSJlDtd64tuiUZA==
+"@aws-sdk/middleware-recursion-detection@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.398.0.tgz#e456d67fc88afac73004a8feae497d3ab24231e4"
+  integrity sha512-7QpOqPQAZNXDXv6vsRex4R8dLniL0E/80OPK4PPFsrCh9btEyhN9Begh4i1T+5lL28hmYkztLOkTQ2N5J3hgRQ==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-retry@3.186.0":
@@ -1990,15 +1914,15 @@
     tslib "^1.8.0"
     uuid "^3.0.0"
 
-"@aws-sdk/middleware-sdk-s3@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.363.0.tgz#35e77ad14b6799b0be1c313d9c8b7ca0ad2f4fdb"
-  integrity sha512-npC8vLCero+vULizrK0QPjNanWbgH4A/2Llc1nO8N005uvUe7co6WglILF2W3guZrFk/0uGEdX67OnLxUD97pw==
+"@aws-sdk/middleware-sdk-s3@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.398.0.tgz#3277c50438a34faedc0f1b6380e62196aeffe331"
+  integrity sha512-yweSMc/TyiFtqc52hFMKQJvTm3i1KCoW5mB3o/Sla6zsHBh+nS6TTaBmo+2kcDIR7AKODwW+FLCTHWiazb7J3Q==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
+    "@aws-sdk/types" "3.398.0"
     "@aws-sdk/util-arn-parser" "3.310.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-sdk-s3@3.6.1":
@@ -2023,14 +1947,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-sdk-sts@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.363.0.tgz#41b10aa8b8004bda9156cadde3b2302a84309e6a"
-  integrity sha512-1yy2Ac50FO8BrODaw5bPWvVrRhaVLqXTFH6iHB+dJLPUkwtY5zLM3Mp+9Ilm7kME+r7oIB1wuO6ZB1Lf4ZszIw==
+"@aws-sdk/middleware-sdk-sts@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.398.0.tgz#f7383c86eedba80666b1a009256a1127d1c4edc6"
+  integrity sha512-+JH76XHEgfVihkY+GurohOQ5Z83zVN1nYcQzwCFnCDTh4dG4KwhnZKG+WPw6XJECocY0R+H0ivofeALHvVWJtQ==
   dependencies:
-    "@aws-sdk/middleware-signing" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/middleware-signing" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-serde@3.186.0":
@@ -2061,17 +1985,17 @@
     "@aws-sdk/util-middleware" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-signing@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.363.0.tgz#81067698e0566584f0ca30be56232758f69e2232"
-  integrity sha512-/7qia715pt9JKYIPDGu22WmdZxD8cfF/5xB+1kmILg7ZtjO0pPuTaCNJ7xiIuFd7Dn7JXp5lop08anX/GOhNRQ==
+"@aws-sdk/middleware-signing@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.398.0.tgz#ad8f73c2e7ab564eea95568e2e109f41af6128ec"
+  integrity sha512-O0KqXAix1TcvZBFt1qoFkHMUNJOSgjJTYS7lFTRKSwgsD27bdW2TM2r9R8DAccWFt5Amjkdt+eOwQMIXPGTm8w==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/signature-v4" "^1.0.1"
-    "@smithy/types" "^1.1.0"
-    "@smithy/util-middleware" "^1.0.1"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-middleware" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-signing@3.6.1":
@@ -2084,13 +2008,13 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/middleware-ssec@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.363.0.tgz#9dde9e09660bcb6a0d39939d7f1ab043b93fefdb"
-  integrity sha512-pN+QN1rMShYpJnTJSCIYnNRhD0S8xSZsTn6ThgcO559Xiwz5LMHFOfOXUCEyxtbVW5kMHLUh3w101AMUKae99A==
+"@aws-sdk/middleware-ssec@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.398.0.tgz#0c4f291e009833858935eb589a94d386cfc45a49"
+  integrity sha512-QtKr/hPcRugKSIZAH4+7hbUfdW7Lg+OQvD25nJn7ic1JHRZ+eDctEFxdsmnt68lE6aZxOcHCWHAW6/umcA93Dw==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-ssec@3.6.1":
@@ -2124,15 +2048,15 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/middleware-user-agent@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.363.0.tgz#a75a7ca5c791a68d750736c87b968b54d394443d"
-  integrity sha512-ri8YaQvXP6odteVTMfxPqFR26Q0h9ejtqhUDv47P34FaKXedEM4nC6ix6o+5FEYj6l8syGyktftZ5O70NoEhug==
+"@aws-sdk/middleware-user-agent@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.398.0.tgz#42542b3697ee6812cb8f81fd19757dc1592af0e0"
+  integrity sha512-nF1jg0L+18b5HvTcYzwyFgfZQQMELJINFqI0mi4yRKaX7T5a3aGp5RVLGGju/6tAGTuFbfBoEhkhU3kkxexPYQ==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@aws-sdk/util-endpoints" "3.357.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/middleware-user-agent@3.6.1":
@@ -2265,6 +2189,20 @@
     "@aws-sdk/util-format-url" "3.6.1"
     tslib "^1.8.0"
 
+"@aws-sdk/s3-request-presigner@^3.400.0":
+  version "3.400.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.400.0.tgz#f9f7f69a1c35ba2f8f82985b296bcc5b721f632a"
+  integrity sha512-6XFzm+sXBy85VKkd9GjGUAHtyfmfCcznvdohQ/1eqqYHWUQrTN4w0hGSWRhu4w7u4mpwoJhR71UF864iWvoCaQ==
+  dependencies:
+    "@aws-sdk/signature-v4-multi-region" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-format-url" "3.398.0"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
 "@aws-sdk/service-error-classification@3.186.0":
   version "3.186.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz#6e4e1d4b53d68bd28c28d9cf0b3b4cb6a6a59dbb"
@@ -2290,15 +2228,15 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/signature-v4-multi-region@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz#7c64ba8a6af6f52f73ef849d4fcdd102f63ad606"
-  integrity sha512-iWamQSpaBKg88LKuiUq8xO/7iyxJ+ORkA3qDhAwUqyTJOg87ma47yFf4ycCKqINnflc3AIGLGzBHnkBc4cMF5g==
+"@aws-sdk/signature-v4-multi-region@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.398.0.tgz#3afc781f59a657962e9fd69c0c82a2b083e349d4"
+  integrity sha512-8fTqTxRDWE03T7ClaWlCfbwuSae//01XMNVy2a9g5QgaelQh7ZZyU3ZIJiV8gIj8v6ZM0NGn9Bz1liI/vmNmcw==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/protocol-http" "^1.1.0"
-    "@smithy/signature-v4" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/signature-v4" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/signature-v4@3.186.0":
@@ -2342,16 +2280,45 @@
     "@aws-sdk/types" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/token-providers@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.363.0.tgz#c211ed6db62620c46194506db6d785f5c36aedc5"
-  integrity sha512-6+0aJ1zugNgsMmhTtW2LBWxOVSaXCUk2q3xyTchSXkNzallYaRiZMRkieW+pKNntnu0g5H1T0zyfCO0tbXwxEA==
+"@aws-sdk/token-providers@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.398.0.tgz#62fc8f5379df0e94486d71b96df975fb7e7d04cc"
+  integrity sha512-nrYgjzavGCKJL/48Vt0EL+OlIc5UZLfNGpgyUW9cv3XZwl+kXV0QB+HH0rHZZLfpbBgZ2RBIJR9uD5ieu/6hpQ==
   dependencies:
-    "@aws-sdk/client-sso-oidc" "3.363.0"
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/property-provider" "^1.0.1"
-    "@smithy/shared-ini-file-loader" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/middleware-host-header" "3.398.0"
+    "@aws-sdk/middleware-logger" "3.398.0"
+    "@aws-sdk/middleware-recursion-detection" "3.398.0"
+    "@aws-sdk/middleware-user-agent" "3.398.0"
+    "@aws-sdk/types" "3.398.0"
+    "@aws-sdk/util-endpoints" "3.398.0"
+    "@aws-sdk/util-user-agent-browser" "3.398.0"
+    "@aws-sdk/util-user-agent-node" "3.398.0"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/hash-node" "^2.0.5"
+    "@smithy/invalid-dependency" "^2.0.5"
+    "@smithy/middleware-content-length" "^2.0.5"
+    "@smithy/middleware-endpoint" "^2.0.5"
+    "@smithy/middleware-retry" "^2.0.5"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/property-provider" "^2.0.0"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/shared-ini-file-loader" "^2.0.0"
+    "@smithy/smithy-client" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-body-length-browser" "^2.0.0"
+    "@smithy/util-body-length-node" "^2.1.0"
+    "@smithy/util-defaults-mode-browser" "^2.0.5"
+    "@smithy/util-defaults-mode-node" "^2.0.5"
+    "@smithy/util-retry" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
 "@aws-sdk/types@3.186.0":
@@ -2359,17 +2326,25 @@
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.186.0.tgz#f6fb6997b6a364f399288bfd5cd494bc680ac922"
   integrity sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==
 
-"@aws-sdk/types@3.357.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0", "@aws-sdk/types@^3.222.0":
-  version "3.357.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.357.0.tgz#8491da71a4291cc2661c26a75089e86532b6a3b5"
-  integrity sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==
+"@aws-sdk/types@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.398.0.tgz#8ce02559536670f9188cddfce32e9dd12b4fe965"
+  integrity sha512-r44fkS+vsEgKCuEuTV+TIk0t0m5ZlXHNjSDYEUvzLStbbfUFiNus/YG4UCa0wOk9R7VuQI67badsvvPeVPCGDQ==
   dependencies:
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/types@3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.6.1.tgz#00686db69e998b521fcd4a5f81ef0960980f80c4"
   integrity sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==
+
+"@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0", "@aws-sdk/types@^3.222.0":
+  version "3.357.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.357.0.tgz#8491da71a4291cc2661c26a75089e86532b6a3b5"
+  integrity sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==
+  dependencies:
+    tslib "^2.5.0"
 
 "@aws-sdk/url-parser-native@3.6.1":
   version "3.6.1"
@@ -2443,14 +2418,6 @@
     "@aws-sdk/util-buffer-from" "3.6.1"
     tslib "^1.8.0"
 
-"@aws-sdk/util-base64@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz#d0fd49aff358c5a6e771d0001c63b1f97acbe34c"
-  integrity sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.310.0"
-    tslib "^2.5.0"
-
 "@aws-sdk/util-body-length-browser@3.186.0":
   version "3.186.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz#a898eda9f874f6974a9c5c60fcc76bcb6beac820"
@@ -2486,14 +2453,6 @@
   dependencies:
     "@aws-sdk/is-array-buffer" "3.186.0"
     tslib "^2.3.1"
-
-"@aws-sdk/util-buffer-from@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz#7a72cb965984d3c6a7e256ae6cf1621f52e54a57"
-  integrity sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==
-  dependencies:
-    "@aws-sdk/is-array-buffer" "3.310.0"
-    tslib "^2.5.0"
 
 "@aws-sdk/util-buffer-from@3.6.1":
   version "3.6.1"
@@ -2542,12 +2501,22 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-endpoints@3.357.0":
-  version "3.357.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz#eaa7b4481bbd9fc8f13412b308ba4129d8fa2004"
-  integrity sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==
+"@aws-sdk/util-endpoints@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.398.0.tgz#cb1cc5fe3e4b3839e4e1cc6a66f834cf0dde20ee"
+  integrity sha512-Fy0gLYAei/Rd6BrXG4baspCnWTUSd0NdokU1pZh4KlfEAEN1i8SPPgfiO5hLk7+2inqtCmqxVJlfqbMVe9k4bw==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
+    "@aws-sdk/types" "3.398.0"
+    tslib "^2.5.0"
+
+"@aws-sdk/util-format-url@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-format-url/-/util-format-url-3.398.0.tgz#dab4089d77f77db1566d8a914da7ebf92cb84817"
+  integrity sha512-Q3kchZZ9+VkR6mORK04wpQXL9LHi88EIPZNfpWSuqV/g1gR+rxcNc3mNe0KjnQ0//IQmcWworfGigHRhDQSsKg==
+  dependencies:
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/querystring-builder" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/util-format-url@3.6.1":
@@ -2610,13 +2579,13 @@
     bowser "^2.11.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-user-agent-browser@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.363.0.tgz#6f0655976f4f5889d6f0abed6c6cdc665cab524f"
-  integrity sha512-fk9ymBUIYbxiGm99Cn+kAAXmvMCWTf/cHAcB79oCXV4ELXdPa9lN5xQhZRFNxLUeXG4OAMEuCAUUuZEj8Fnc1Q==
+"@aws-sdk/util-user-agent-browser@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.398.0.tgz#5c3e430032eb867b7cbe48dda51a6d8c4ea000a8"
+  integrity sha512-A3Tzx1tkDHlBT+IgxmsMCHbV8LM7SwwCozq2ZjJRx0nqw3MCrrcxQFXldHeX/gdUMO+0Oocb7HGSnVODTq+0EA==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/types" "^2.2.2"
     bowser "^2.11.0"
     tslib "^2.5.0"
 
@@ -2638,14 +2607,14 @@
     "@aws-sdk/types" "3.186.0"
     tslib "^2.3.1"
 
-"@aws-sdk/util-user-agent-node@3.363.0":
-  version "3.363.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.363.0.tgz#9df26188a3d22694b4d06f5f40c489cb22fddb48"
-  integrity sha512-Fli/dvgGA9hdnQUrYb1//wNSFlK2jAfdJcfNXA6SeBYzSeH5pVGYF4kXF0FCdnMA3Fef+Zn1zAP/hw9v8VJHWQ==
+"@aws-sdk/util-user-agent-node@3.398.0":
+  version "3.398.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.398.0.tgz#1707737ee67c864d74a03137003b6d2b28172ee6"
+  integrity sha512-RTVQofdj961ej4//fEkppFf4KXqKGMTCqJYghx3G0C/MYXbg7MGl7LjfNGtJcboRE8pfHHQ/TUWBDA7RIAPPlQ==
   dependencies:
-    "@aws-sdk/types" "3.357.0"
-    "@smithy/node-config-provider" "^1.0.1"
-    "@smithy/types" "^1.1.0"
+    "@aws-sdk/types" "3.398.0"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@aws-sdk/util-user-agent-node@3.6.1":
@@ -2693,14 +2662,6 @@
   dependencies:
     "@aws-sdk/util-buffer-from" "3.6.1"
     tslib "^1.8.0"
-
-"@aws-sdk/util-utf8@3.310.0":
-  version "3.310.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz#4a7b9dcebb88e830d3811aeb21e9a6df4273afb4"
-  integrity sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==
-  dependencies:
-    "@aws-sdk/util-buffer-from" "3.310.0"
-    tslib "^2.5.0"
 
 "@aws-sdk/util-waiter@3.6.1":
   version "3.6.1"
@@ -5154,388 +5115,431 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@smithy/abort-controller@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-1.0.2.tgz#74caac052ecea15c5460438272ad8d43a6ccbc53"
-  integrity sha512-tb2h0b+JvMee+eAxTmhnyqyNk51UXIK949HnE14lFeezKsVJTB30maan+CO2IMwnig2wVYQH84B5qk6ylmKCuA==
+"@smithy/abort-controller@^2.0.1", "@smithy/abort-controller@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-2.0.5.tgz#9602a9b362e84c0d043d820c4aba5d9b78028a84"
+  integrity sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==
   dependencies:
-    "@smithy/types" "^1.1.1"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/config-resolver@^1.0.1", "@smithy/config-resolver@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-1.0.2.tgz#d4f556a44292b41b5c067662a4bd5049dea40e35"
-  integrity sha512-8Bk7CgnVKg1dn5TgnjwPz2ebhxeR7CjGs5yhVYH3S8x0q8yPZZVWwpRIglwXaf5AZBzJlNO1lh+lUhMf2e73zQ==
+"@smithy/chunked-blob-reader-native@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.0.0.tgz#f6d0eeeb5481026b68b054f45540d924c194d558"
+  integrity sha512-HM8V2Rp1y8+1343tkZUKZllFhEQPNmpNdgFAncbTsxkZ18/gqjk23XXv3qGyXWp412f3o43ZZ1UZHVcHrpRnCQ==
   dependencies:
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-config-provider" "^1.0.2"
-    "@smithy/util-middleware" "^1.0.2"
+    "@smithy/util-base64" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/credential-provider-imds@^1.0.1", "@smithy/credential-provider-imds@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-1.0.2.tgz#7aa797c0d95448eb3dccb988b40e62db8989576f"
-  integrity sha512-fLjCya+JOu2gPJpCiwSUyoLvT8JdNJmOaTOkKYBZoGf7CzqR6lluSyI+eboZnl/V0xqcfcqBG4tgqCISmWS3/w==
+"@smithy/chunked-blob-reader@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.0.0.tgz#c44fe2c780eaf77f9e5381d982ac99a880cce51b"
+  integrity sha512-k+J4GHJsMSAIQPChGBrjEmGS+WbPonCXesoqP9fynIqjn7rdOThdH8FAeCmokP9mxTYKQAKoHCLPzNlm6gh7Wg==
   dependencies:
-    "@smithy/node-config-provider" "^1.0.2"
-    "@smithy/property-provider" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    "@smithy/url-parser" "^1.0.2"
     tslib "^2.5.0"
 
-"@smithy/eventstream-codec@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-1.0.2.tgz#06d1b6e2510cb2475a39b3a20b0c75e751917c59"
-  integrity sha512-eW/XPiLauR1VAgHKxhVvgvHzLROUgTtqat2lgljztbH8uIYWugv7Nz+SgCavB+hWRazv2iYgqrSy74GvxXq/rg==
+"@smithy/config-resolver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-2.0.5.tgz#d64c1c83a773ca5a038146d4b537c202b6c6bfaf"
+  integrity sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-config-provider" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/credential-provider-imds@^2.0.0", "@smithy/credential-provider-imds@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz#59e6f8d30beed9e966d418f47108bb4da371bbae"
+  integrity sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==
+  dependencies:
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/property-provider" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    tslib "^2.5.0"
+
+"@smithy/eventstream-codec@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-codec/-/eventstream-codec-2.0.5.tgz#771f50657f1958db3e19b9f2726d62e2e0672546"
+  integrity sha512-iqR6OuOV3zbQK8uVs9o+9AxhVk8kW9NAxA71nugwUB+kTY9C35pUd0A5/m4PRT0Y0oIW7W4kgnSR3fdYXQjECw==
   dependencies:
     "@aws-crypto/crc32" "3.0.0"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-hex-encoding" "^1.0.2"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-hex-encoding" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/eventstream-serde-browser@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.0.2.tgz#2f6c9de876ca5e3f35388df9cfa31aeb4281ac76"
-  integrity sha512-8bDImzBewLQrIF6hqxMz3eoYwEus2E5JrEwKnhpkSFkkoj8fDSKiLeP/26xfcaoVJgZXB8M1c6jSEZiY3cUMsw==
+"@smithy/eventstream-serde-browser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.5.tgz#5f4d3d78a9fcb0a5a6f5b20f69141c8cc6b0ef6b"
+  integrity sha512-8NU51y94qFJbxL6SmvgWDfITHO/svvbAigkLYk2pckX17TGCSf4EXuGpGLliJp5Ljh5+vASC7mUH2jYX7MWBxA==
   dependencies:
-    "@smithy/eventstream-serde-universal" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/eventstream-serde-universal" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/eventstream-serde-config-resolver@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.0.2.tgz#37a55970c31f3e4a38d66933ab14398351553daf"
-  integrity sha512-SeiJ5pfrXzkGP4WCt9V3Pimfr3OM85Nyh9u/V4J6E0O2dLOYuqvSuKdVnktV0Tcmuu1ZYbt78Th0vfetnSEcdQ==
+"@smithy/eventstream-serde-config-resolver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.5.tgz#1e551a308dc2e91b8c732815077dbf99beb1300f"
+  integrity sha512-u3gvukRaTH4X6tsryuZ4T1WGIEP34fPaTTzphFDJe8GJz/k11oBW1MPnkcaucBMxLnObK9swCF85j5cp1Kj1oA==
   dependencies:
-    "@smithy/types" "^1.1.1"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/eventstream-serde-node@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.0.2.tgz#1c8ba86f70ecdad19c3a25b48b0f9a03799c2a0d"
-  integrity sha512-jqSfi7bpOBHqgd5OgUtCX0wAVhPqxlVdqcj2c4gHaRRXcbpCmK0DRDg7P+Df0h4JJVvTqI6dy2c0YhHk5ehPCw==
+"@smithy/eventstream-serde-node@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.5.tgz#ceea04afcef95caf0e4148c606721c1882a1d9b5"
+  integrity sha512-/C8jb+k/vKUBIe80D30vzjvRXlJf76kG2AJY7/NwiqWuD2usRuuDFCDaswXdVsSh9P1+FeaxZ48chsK10yDryQ==
   dependencies:
-    "@smithy/eventstream-serde-universal" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/eventstream-serde-universal" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/eventstream-serde-universal@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.0.2.tgz#66c1ccc639cb64049291200bcda476b26875fd8e"
-  integrity sha512-cQ9bT0j0x49cp8TQ1yZSnn4+9qU0WQSTkoucl3jKRoTZMzNYHg62LQao6HTQ3Jgd77nAXo00c7hqUEjHXwNA+A==
+"@smithy/eventstream-serde-universal@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.5.tgz#5a656557575ee4ad69515434e45f19f7816f09f8"
+  integrity sha512-+vHvbQtlSVYTQ/20tNpVaKi0EpTR7E8GoEUHJypRZIRgiT03b3h2MAWk+SNaqMrCJrYG9vKLkJFzDylRlUvDWg==
   dependencies:
-    "@smithy/eventstream-codec" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/eventstream-codec" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/fetch-http-handler@^1.0.1", "@smithy/fetch-http-handler@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-1.0.2.tgz#4186ee6451de22e867f43c05236dcff43eca6e91"
-  integrity sha512-kynyofLf62LvR8yYphPPdyHb8fWG3LepFinM/vWUTG2Q1pVpmPCM530ppagp3+q2p+7Ox0UvSqldbKqV/d1BpA==
+"@smithy/fetch-http-handler@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz#822510720598b4306e7c71e839eea34b6928c66b"
+  integrity sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==
   dependencies:
-    "@smithy/protocol-http" "^1.1.1"
-    "@smithy/querystring-builder" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-base64" "^1.0.2"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/querystring-builder" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-base64" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/hash-node@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-1.0.2.tgz#dc65203a348d29e45c493ead3e772e4f7dfb5bc0"
-  integrity sha512-K6PKhcUNrJXtcesyzhIvNlU7drfIU7u+EMQuGmPw6RQDAg/ufUcfKHz4EcUhFAodUmN+rrejhRG9U6wxjeBOQA==
+"@smithy/hash-blob-browser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.5.tgz#5cc622f6d448f3e87134eb6d4c4b608b5a4e2002"
+  integrity sha512-ZVAUBtJXGf9bEko4/RwWcTK6d3b/ZmQMxJMrxOOcQhVDiqny9zI0mzgstO4Oxz3135R7S3V/bbGw3w3woCYpQg==
   dependencies:
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-buffer-from" "^1.0.2"
-    "@smithy/util-utf8" "^1.0.2"
+    "@smithy/chunked-blob-reader" "^2.0.0"
+    "@smithy/chunked-blob-reader-native" "^2.0.0"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/invalid-dependency@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-1.0.2.tgz#0a9d82d1a14e5bdbdc0bd2cef5f457c85a942920"
-  integrity sha512-B1Y3Tsa6dfC+Vvb+BJMhTHOfFieeYzY9jWQSTR1vMwKkxsymD0OIAnEw8rD/RiDj/4E4RPGFdx9Mdgnyd6Bv5Q==
+"@smithy/hash-node@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-2.0.5.tgz#f3558c1553f846148c3e5d10a815429e1b357668"
+  integrity sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==
   dependencies:
-    "@smithy/types" "^1.1.1"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/is-array-buffer@^1.0.1", "@smithy/is-array-buffer@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-1.0.2.tgz#224702a2364d698f0a36ecb2c240c0c9541ecfb6"
-  integrity sha512-pkyBnsBRpe+c/6ASavqIMRBdRtZNJEVJOEzhpxZ9JoAXiZYbkfaSMRA/O1dUxGdJ653GHONunnZ4xMo/LJ7utQ==
+"@smithy/hash-stream-node@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-stream-node/-/hash-stream-node-2.0.5.tgz#98175965ee7057312b464fcd63e8e1bd4142e38e"
+  integrity sha512-XiR4Aoux5kXy8OWPLQisKy3GPmm0l6deHepvPvr4MUzIwa5XWazG3JdbZXy+mk93CvEZrOwKPHU5Kul6QybJiQ==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/invalid-dependency@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz#b07bdbc43403977b8bcae6de19a96e184f2eb655"
+  integrity sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/is-array-buffer@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz#8fa9b8040651e7ba0b2f6106e636a91354ff7d34"
+  integrity sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/middleware-content-length@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-1.0.2.tgz#63099f8d01b3419b65e21cfd07b0c2ef47d1f473"
-  integrity sha512-pa1/SgGIrSmnEr2c9Apw7CdU4l/HW0fK3+LKFCPDYJrzM0JdYpqjQzgxi31P00eAkL0EFBccpus/p1n2GF9urw==
+"@smithy/md5-js@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/md5-js/-/md5-js-2.0.5.tgz#02173e4e21105819efa8ebaa17eab23d5663f896"
+  integrity sha512-k5EOte/Ye2r7XBVaXv2rhiehk6l3T4uRiPF+pnxKEc+G9Fwd1xAXBDZrtOq1syFPBKBmVfNszG4nevngST7NKg==
   dependencies:
-    "@smithy/protocol-http" "^1.1.1"
-    "@smithy/types" "^1.1.1"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-utf8" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/middleware-endpoint@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-1.0.3.tgz#ff4b1c0a83eb8d8b8d3937f434a95efbbf43e1cd"
-  integrity sha512-GsWvTXMFjSgl617PCE2km//kIjjtvMRrR2GAuRDIS9sHiLwmkS46VWaVYy+XE7ubEsEtzZ5yK2e8TKDR6Qr5Lw==
+"@smithy/middleware-content-length@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz#b2008c6b664c4c67fb255ef5a9fd5f4bd2c914f6"
+  integrity sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==
   dependencies:
-    "@smithy/middleware-serde" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    "@smithy/url-parser" "^1.0.2"
-    "@smithy/util-middleware" "^1.0.2"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/middleware-retry@^1.0.1", "@smithy/middleware-retry@^1.0.2":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-1.0.4.tgz#8e9de0713dac7f7af405477d46bd4525ca7b9ea8"
-  integrity sha512-G7uRXGFL8c3F7APnoIMTtNAHH8vT4F2qVnAWGAZaervjupaUQuRRHYBLYubK0dWzOZz86BtAXKieJ5p+Ni2Xpg==
+"@smithy/middleware-endpoint@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz#6a16361dc527262958194e48343733ac6285776b"
+  integrity sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==
   dependencies:
-    "@smithy/protocol-http" "^1.1.1"
-    "@smithy/service-error-classification" "^1.0.3"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-middleware" "^1.0.2"
-    "@smithy/util-retry" "^1.0.4"
+    "@smithy/middleware-serde" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/url-parser" "^2.0.5"
+    "@smithy/util-middleware" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/middleware-retry@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz#bbf8858aeccdfe11837f89635cb6ce8a8e304518"
+  integrity sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==
+  dependencies:
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/service-error-classification" "^2.0.0"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-middleware" "^2.0.0"
+    "@smithy/util-retry" "^2.0.0"
     tslib "^2.5.0"
     uuid "^8.3.2"
 
-"@smithy/middleware-serde@^1.0.1", "@smithy/middleware-serde@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-1.0.2.tgz#87b3a0211602ae991d9b756893eb6bf2e3e5f711"
-  integrity sha512-T4PcdMZF4xme6koUNfjmSZ1MLi7eoFeYCtodQNQpBNsS77TuJt1A6kt5kP/qxrTvfZHyFlj0AubACoaUqgzPeg==
+"@smithy/middleware-serde@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz#3f3635cb437a3fba46cd1407d3adf53d41328574"
+  integrity sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==
   dependencies:
-    "@smithy/types" "^1.1.1"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/middleware-stack@^1.0.1", "@smithy/middleware-stack@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-1.0.2.tgz#d241082bf3cb315c749dda57e233039a9aed804e"
-  integrity sha512-H7/uAQEcmO+eDqweEFMJ5YrIpsBwmrXSP6HIIbtxKJSQpAcMGY7KrR2FZgZBi1FMnSUOh+rQrbOyj5HQmSeUBA==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/node-config-provider@^1.0.1", "@smithy/node-config-provider@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-1.0.2.tgz#2d391b96a9e10072e7e0a3698427400f4ef17ec4"
-  integrity sha512-HU7afWpTToU0wL6KseGDR2zojeyjECQfr8LpjAIeHCYIW7r360ABFf4EaplaJRMVoC3hD9FeltgI3/NtShOqCg==
-  dependencies:
-    "@smithy/property-provider" "^1.0.2"
-    "@smithy/shared-ini-file-loader" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/node-http-handler@^1.0.1", "@smithy/node-http-handler@^1.0.2", "@smithy/node-http-handler@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-1.0.3.tgz#89b556ca2bdcce7a994a9da1ea265094d76d4791"
-  integrity sha512-PcPUSzTbIb60VCJCiH0PU0E6bwIekttsIEf5Aoo/M0oTfiqsxHTn0Rcij6QoH6qJy6piGKXzLSegspXg5+Kq6g==
-  dependencies:
-    "@smithy/abort-controller" "^1.0.2"
-    "@smithy/protocol-http" "^1.1.1"
-    "@smithy/querystring-builder" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/property-provider@^1.0.1", "@smithy/property-provider@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-1.0.2.tgz#f99f104cbd6576c9aca9f56cb72819b4a65208e1"
-  integrity sha512-pXDPyzKX8opzt38B205kDgaxda6LHcTfPvTYQZnwP6BAPp1o9puiCPjeUtkKck7Z6IbpXCPUmUQnzkUzWTA42Q==
-  dependencies:
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/protocol-http@^1.0.1", "@smithy/protocol-http@^1.1.0", "@smithy/protocol-http@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-1.1.1.tgz#10977cf71631eed4f5ad1845408920238d52cdba"
-  integrity sha512-mFLFa2sSvlUxm55U7B4YCIsJJIMkA6lHxwwqOaBkral1qxFz97rGffP/mmd4JDuin1EnygiO5eNJGgudiUgmDQ==
-  dependencies:
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/querystring-builder@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-1.0.2.tgz#ce861f6cbd14792c83aa19b4967a19923bd0706e"
-  integrity sha512-6P/xANWrtJhMzTPUR87AbXwSBuz1SDHIfL44TFd/GT3hj6rA+IEv7rftEpPjayUiWRocaNnrCPLvmP31mobOyA==
-  dependencies:
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-uri-escape" "^1.0.2"
-    tslib "^2.5.0"
-
-"@smithy/querystring-parser@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-1.0.2.tgz#559d09c46b21e6fbda71e95deda4bcd8a46bdecc"
-  integrity sha512-IWxwxjn+KHWRRRB+K2Ngl+plTwo2WSgc2w+DvLy0DQZJh9UGOpw40d6q97/63GBlXIt4TEt5NbcFrO30CKlrsA==
-  dependencies:
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/service-error-classification@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-1.0.3.tgz#c620c1562610d3351985eb6dd04262ca2657ae67"
-  integrity sha512-2eglIYqrtcUnuI71yweu7rSfCgt6kVvRVf0C72VUqrd0LrV1M0BM0eYN+nitp2CHPSdmMI96pi+dU9U/UqAMSA==
-
-"@smithy/shared-ini-file-loader@^1.0.1", "@smithy/shared-ini-file-loader@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.0.2.tgz#c6e79991d87925bd18e0adae00c97da6c8ecae1e"
-  integrity sha512-bdQj95VN+lCXki+P3EsDyrkpeLn8xDYiOISBGnUG/AGPYJXN8dmp4EhRRR7XOoLoSs8anZHR4UcGEOzFv2jwGw==
-  dependencies:
-    "@smithy/types" "^1.1.1"
-    tslib "^2.5.0"
-
-"@smithy/signature-v4@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-1.0.2.tgz#3a7b10ac66c337b404aa061e5f268f0550729680"
-  integrity sha512-rpKUhmCuPmpV5dloUkOb9w1oBnJatvKQEjIHGmkjRGZnC3437MTdzWej9TxkagcZ8NRRJavYnEUixzxM1amFig==
-  dependencies:
-    "@smithy/eventstream-codec" "^1.0.2"
-    "@smithy/is-array-buffer" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-hex-encoding" "^1.0.2"
-    "@smithy/util-middleware" "^1.0.2"
-    "@smithy/util-uri-escape" "^1.0.2"
-    "@smithy/util-utf8" "^1.0.2"
-    tslib "^2.5.0"
-
-"@smithy/smithy-client@^1.0.2", "@smithy/smithy-client@^1.0.3":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-1.0.4.tgz#96d03d123d117a637c679a79bb8eae96e3857bd9"
-  integrity sha512-gpo0Xl5Nyp9sgymEfpt7oa9P2q/GlM3VmQIdm+FeH0QEdYOQx3OtvwVmBYAMv2FIPWxkMZlsPYRTnEiBTK5TYg==
-  dependencies:
-    "@smithy/middleware-stack" "^1.0.2"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-stream" "^1.0.2"
-    tslib "^2.5.0"
-
-"@smithy/types@^1.0.0", "@smithy/types@^1.1.0", "@smithy/types@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-1.1.1.tgz#949394a22e13e7077471bae0d18c146e5f62c456"
-  integrity sha512-tMpkreknl2gRrniHeBtdgQwaOlo39df8RxSrwsHVNIGXULy5XP6KqgScUw2m12D15wnJCKWxVhCX+wbrBW/y7g==
+"@smithy/middleware-stack@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz#cd9f442c2788b1ef0ea6b32236d80c76b3c342e9"
+  integrity sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/url-parser@^1.0.1", "@smithy/url-parser@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-1.0.2.tgz#fb59be6f2283399443d9e7afe08ebf63b3c266bb"
-  integrity sha512-0JRsDMQe53F6EHRWksdcavKDRjyqp8vrjakg8EcCUOa7PaFRRB1SO/xGZdzSlW1RSTWQDEksFMTCEcVEKmAoqA==
+"@smithy/node-config-provider@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz#239a6281e1d0bc2a0dd8fdab7826bacd25dfbf00"
+  integrity sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==
   dependencies:
-    "@smithy/querystring-parser" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/property-provider" "^2.0.5"
+    "@smithy/shared-ini-file-loader" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/util-base64@^1.0.1", "@smithy/util-base64@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-1.0.2.tgz#6cdd5a9356dafad3c531123c12cd77d674762da0"
-  integrity sha512-BCm15WILJ3SL93nusoxvJGMVfAMWHZhdeDZPtpAaskozuexd0eF6szdz4kbXaKp38bFCSenA6bkUHqaE3KK0dA==
+"@smithy/node-http-handler@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz#19c1bdd4d61502bc9c793dddb8ce995626ca6585"
+  integrity sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==
   dependencies:
-    "@smithy/util-buffer-from" "^1.0.2"
+    "@smithy/abort-controller" "^2.0.5"
+    "@smithy/protocol-http" "^2.0.5"
+    "@smithy/querystring-builder" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/util-body-length-browser@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-1.0.2.tgz#4a9a49497634b5f25ab5ff73f1a8498010b0024a"
-  integrity sha512-Xh8L06H2anF5BHjSYTg8hx+Itcbf4SQZnVMl4PIkCOsKtneMJoGjPRLy17lEzfoh/GOaa0QxgCP6lRMQWzNl4w==
+"@smithy/property-provider@^2.0.0", "@smithy/property-provider@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-2.0.5.tgz#7cc88bc56706a4758076754a71c6a9ebf5daa8a7"
+  integrity sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/protocol-http@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-2.0.5.tgz#ff7779fc8fcd3fe52e71fd07565b518f0937e8ba"
+  integrity sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/querystring-builder@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz#c5a873769de56ef57ae3b4d2c58fc7f68184a89c"
+  integrity sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-uri-escape" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/querystring-parser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz#aec6733ed4497402634978e7026d0d00661594d6"
+  integrity sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/service-error-classification@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz#bbce07c9c529d9333d40db881fd4a1795dd84892"
+  integrity sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==
+
+"@smithy/shared-ini-file-loader@^2.0.0", "@smithy/shared-ini-file-loader@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz#c2b28b499f2b9928e892a80fcdeb259b2938475c"
+  integrity sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==
+  dependencies:
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/signature-v4@^2.0.0":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-2.0.5.tgz#48fbc1a25f2f44bbd9217927518c8fe439419f4d"
+  integrity sha512-ABIzXmUDXK4n2c9cXjQLELgH2RdtABpYKT+U131e2I6RbCypFZmxIHmIBufJzU2kdMCQ3+thBGDWorAITFW04A==
+  dependencies:
+    "@smithy/eventstream-codec" "^2.0.5"
+    "@smithy/is-array-buffer" "^2.0.0"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-middleware" "^2.0.0"
+    "@smithy/util-uri-escape" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/smithy-client@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-2.0.5.tgz#7941449f146d2c61d34670779d77d4a085141bc1"
+  integrity sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==
+  dependencies:
+    "@smithy/middleware-stack" "^2.0.0"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-stream" "^2.0.5"
+    tslib "^2.5.0"
+
+"@smithy/types@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.2.2.tgz#bd8691eb92dd07ac33b83e0e1c45f283502b1bf7"
+  integrity sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-body-length-node@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-1.0.2.tgz#bc4969022f7d9ffcb239d626d80a85138e986df6"
-  integrity sha512-nXHbZsUtvZeyfL4Ceds9nmy2Uh2AhWXohG4vWHyjSdmT8cXZlJdmJgnH6SJKDjyUecbu+BpKeVvSrA4cWPSOPA==
+"@smithy/url-parser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-2.0.5.tgz#09fa623076bb5861892930628bf368d5c79fd7d9"
+  integrity sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==
+  dependencies:
+    "@smithy/querystring-parser" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    tslib "^2.5.0"
+
+"@smithy/util-base64@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-2.0.0.tgz#1beeabfb155471d1d41c8d0603be1351f883c444"
+  integrity sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-body-length-browser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz#5447853003b4c73da3bc5f3c5e82c21d592d1650"
+  integrity sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-buffer-from@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-1.0.2.tgz#27e19573d721962bd2443f23d4edadb8206b2cb5"
-  integrity sha512-lHAYIyrBO9RANrPvccnPjU03MJnWZ66wWuC5GjWWQVfsmPwU6m00aakZkzHdUT6tGCkGacXSgArP5wgTgA+oCw==
-  dependencies:
-    "@smithy/is-array-buffer" "^1.0.2"
-    tslib "^2.5.0"
-
-"@smithy/util-config-provider@^1.0.1", "@smithy/util-config-provider@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-1.0.2.tgz#4d2e867df1cc7b4010d1278bd5767ce1b679dae9"
-  integrity sha512-HOdmDm+3HUbuYPBABLLHtn8ittuRyy+BSjKOA169H+EMc+IozipvXDydf+gKBRAxUa4dtKQkLraypwppzi+PRw==
+"@smithy/util-body-length-node@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz#313a5f7c5017947baf5fa018bfc22628904bbcfa"
+  integrity sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-defaults-mode-browser@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.0.2.tgz#31ad7b9bce7e38fd57f4a370ee416373b4fbd432"
-  integrity sha512-J1u2PO235zxY7dg0+ZqaG96tFg4ehJZ7isGK1pCBEA072qxNPwIpDzUVGnLJkHZvjWEGA8rxIauDtXfB0qxeAg==
+"@smithy/util-buffer-from@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz#7eb75d72288b6b3001bc5f75b48b711513091deb"
+  integrity sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==
   dependencies:
-    "@smithy/property-provider" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/is-array-buffer" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-config-provider@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz#4dd6a793605559d94267312fd06d0f58784b4c38"
+  integrity sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-defaults-mode-browser@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz#36d5424749d324bd69f37c74ea20a183f8c2286e"
+  integrity sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==
+  dependencies:
+    "@smithy/property-provider" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     bowser "^2.11.0"
     tslib "^2.5.0"
 
-"@smithy/util-defaults-mode-node@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.0.2.tgz#b295fe2a18568c1e21a85b6557e2b769452b4d95"
-  integrity sha512-9/BN63rlIsFStvI+AvljMh873Xw6bbI6b19b+PVYXyycQ2DDQImWcjnzRlHW7eP65CCUNGQ6otDLNdBQCgMXqg==
+"@smithy/util-defaults-mode-node@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz#504dd39a603fd2d67e53537c794dd57e6541baae"
+  integrity sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==
   dependencies:
-    "@smithy/config-resolver" "^1.0.2"
-    "@smithy/credential-provider-imds" "^1.0.2"
-    "@smithy/node-config-provider" "^1.0.2"
-    "@smithy/property-provider" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/config-resolver" "^2.0.5"
+    "@smithy/credential-provider-imds" "^2.0.5"
+    "@smithy/node-config-provider" "^2.0.5"
+    "@smithy/property-provider" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
-"@smithy/util-hex-encoding@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-1.0.2.tgz#5b9f2162f2a59b2d2aa39992bd2c7f65b6616ab6"
-  integrity sha512-Bxydb5rMJorMV6AuDDMOxro3BMDdIwtbQKHpwvQFASkmr52BnpDsWlxgpJi8Iq7nk1Bt4E40oE1Isy/7ubHGzg==
-  dependencies:
-    tslib "^2.5.0"
-
-"@smithy/util-middleware@^1.0.1", "@smithy/util-middleware@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-1.0.2.tgz#c3d4c7a6cd31bde33901e54abd7700c8ca73dab3"
-  integrity sha512-vtXK7GOR2BoseCX8NCGe9SaiZrm9M2lm/RVexFGyPuafTtry9Vyv7hq/vw8ifd/G/pSJ+msByfJVb1642oQHKw==
+"@smithy/util-hex-encoding@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz#0aa3515acd2b005c6d55675e377080a7c513b59e"
+  integrity sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-retry@^1.0.1", "@smithy/util-retry@^1.0.2", "@smithy/util-retry@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-1.0.4.tgz#9d95df3884981414163d5f780d38e3529384d9ad"
-  integrity sha512-RnZPVFvRoqdj2EbroDo3OsnnQU8eQ4AlnZTOGusbYKybH3269CFdrZfZJloe60AQjX7di3J6t/79PjwCLO5Khw==
-  dependencies:
-    "@smithy/service-error-classification" "^1.0.3"
-    tslib "^2.5.0"
-
-"@smithy/util-stream@^1.0.1", "@smithy/util-stream@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-1.0.2.tgz#2d33aa5168e51d1dd7937c32a09c8334d2da44d9"
-  integrity sha512-qyN2M9QFMTz4UCHi6GnBfLOGYKxQZD01Ga6nzaXFFC51HP/QmArU72e4kY50Z/EtW8binPxspP2TAsGbwy9l3A==
-  dependencies:
-    "@smithy/fetch-http-handler" "^1.0.2"
-    "@smithy/node-http-handler" "^1.0.3"
-    "@smithy/types" "^1.1.1"
-    "@smithy/util-base64" "^1.0.2"
-    "@smithy/util-buffer-from" "^1.0.2"
-    "@smithy/util-hex-encoding" "^1.0.2"
-    "@smithy/util-utf8" "^1.0.2"
-    tslib "^2.5.0"
-
-"@smithy/util-uri-escape@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-1.0.2.tgz#c69a5423c9baa7a045a79372320bd40a437ac756"
-  integrity sha512-k8C0BFNS9HpBMHSgUDnWb1JlCQcFG+PPlVBq9keP4Nfwv6a9Q0yAfASWqUCtzjuMj1hXeLhn/5ADP6JxnID1Pg==
+"@smithy/util-middleware@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-2.0.0.tgz#706681d4a1686544a2275f68266304233f372c99"
+  integrity sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==
   dependencies:
     tslib "^2.5.0"
 
-"@smithy/util-utf8@^1.0.1", "@smithy/util-utf8@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-1.0.2.tgz#b34c27b4efbe4f0edb6560b6d4f743088302671f"
-  integrity sha512-V4cyjKfJlARui0dMBfWJMQAmJzoW77i4N3EjkH/bwnE2Ngbl4tqD2Y0C/xzpzY/J1BdxeCKxAebVFk8aFCaSCw==
+"@smithy/util-retry@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-2.0.0.tgz#7ac5d5f12383a9d9b2a43f9ff25f3866c8727c24"
+  integrity sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==
   dependencies:
-    "@smithy/util-buffer-from" "^1.0.2"
+    "@smithy/service-error-classification" "^2.0.0"
     tslib "^2.5.0"
 
-"@smithy/util-waiter@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-1.0.2.tgz#3b1498a2d4b92e78eafacc8c76f314e30eb7a5e9"
-  integrity sha512-+jq4/Vd9ejPzR45qwYSePyjQbqYP9QqtyZYsFVyfzRnbGGC0AjswOh7txcxroafuEBExK4qE+L/QZA8wWXsJYw==
+"@smithy/util-stream@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-2.0.5.tgz#a59f6e5327dfa23c3302f578ea023674fc7fa42f"
+  integrity sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==
   dependencies:
-    "@smithy/abort-controller" "^1.0.2"
-    "@smithy/types" "^1.1.1"
+    "@smithy/fetch-http-handler" "^2.0.5"
+    "@smithy/node-http-handler" "^2.0.5"
+    "@smithy/types" "^2.2.2"
+    "@smithy/util-base64" "^2.0.0"
+    "@smithy/util-buffer-from" "^2.0.0"
+    "@smithy/util-hex-encoding" "^2.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-uri-escape@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz#19955b1a0f517a87ae77ac729e0e411963dfda95"
+  integrity sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.0.0.tgz#b4da87566ea7757435e153799df9da717262ad42"
+  integrity sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.0.0"
+    tslib "^2.5.0"
+
+"@smithy/util-waiter@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-2.0.5.tgz#e42161e03c53cf6726dca049ad9a105ea0967435"
+  integrity sha512-1lkkUmI/bhaDX+LIT3RiUNAn+NzPmsWjE7beMq0oQ3H1/CffaILIN67riDA0aE1YBj6xll7uWMIy4tJqc+peXw==
+  dependencies:
+    "@smithy/abort-controller" "^2.0.5"
+    "@smithy/types" "^2.2.2"
     tslib "^2.5.0"
 
 "@surma/rollup-plugin-off-main-thread@^2.2.3":
@@ -8334,6 +8338,14 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 buffer@^5.4.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -10060,7 +10072,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.1.0, events@^3.2.0:
+events@3.3.0, events@^3.1.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -11019,7 +11031,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -14401,7 +14413,7 @@ readable-stream@^2.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6:
+readable-stream@^3.0.6, readable-stream@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -15158,6 +15170,14 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+stream-browserify@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
*Description of changes:*

This change prevents authenticated users from using their temporary web credentials to access asset resources in the asset storage bucket without authorization in VAMS in environments where database ACLs are in use. This doesn't impact unauthenticated users – they never had access to the S3 bucket.

Users in the super-admin group maintain full access to the Asset bucket. For other users, we remove general access to the S3 Asset storage bucket at the authenticated role level in Cognito. Instead, access to assets is provided with temporary credentials that are scoped to one asset at a time. This applies to both uploading and downloading from S3 in the browser.

We still use presigned URLs in the same places as before, but now we leverage the asset-scoped credentials to maintain the same support level for resumable uploads. We base the new implementation largely on the upload functionality in aws-amplify, but we've refactored it to use @aws-sdk/client-s3 and the new credentials mechanism.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
