### PR TITLE
fix: Allow running of NodeJS 16 and/or 18

### DIFF
--- a/infra/lib/infra-stack.ts
+++ b/infra/lib/infra-stack.ts
@@ -278,7 +278,7 @@ export class VAMS extends cdk.Stack {
                 const fn = item as cdk.aws_lambda.Function;
                 // python3.9 suppressed for CDK Bucket Deployment
                 // nodejs14.x suppressed for use of custom resource to deploy saml in CustomCognitoConfigConstruct
-                if (fn.runtime.name === "python3.9" || fn.runtime.name === "nodejs14.x") {
+                if (fn.runtime.name === "python3.9" || fn.runtime.name === "nodejs14.x" || fn.runtime.name === "nodejs16.x" || fn.runtime.name === "nodejs18.x") {
                     NagSuppressions.addResourceSuppressions(fn, [
                         {
                             id: "AwsSolutions-L1",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Currently NodeJS 16+18 fails to build with the following errors:

```
[Error at /vams-poc-eu-central-1/AOSS/OpensearchServerlessDeploySchema/Resource] AwsSolutions-L1: The non-container Lambda function is not configured to use the latest runtime version. Use the latest available runtime for the targeted language to avoid technical debt. Runtimes specific to a language or framework version are deprecated when the version reaches end of life. This rule only applies to non-container Lambda functions.

[Error at /vams-poc-eu-central-1/AmplifyConfig/Lambda/Resource] AwsSolutions-L1: The non-container Lambda function is not configured to use the latest runtime version. Use the latest available runtime for the targeted language to avoid technical debt. Runtimes specific to a language or framework version are deprecated when the version reaches end of life. This rule only applies to non-container Lambda functions.

[Error at /vams-poc-eu-central-1/AmplifyConfig/AuthorizerLambda/Resource] AwsSolutions-L1: The non-container Lambda function is not configured to use the latest runtime version. Use the latest available runtime for the targeted language to avoid technical debt. Runtimes specific to a language or framework version are deprecated when the version reaches end of life. This rule only applies to non-container Lambda functions.


Found errors
```

This resolves the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
