### PR TITLE
Fix to enable building on m1 mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can identify stable releases by their tag. Fetch the tags `git fetch --all -
 
 6. Set the CDK stack name and the region for deployment with environment variables `export AWS_REGION=us-east-1 && export STACK_NAME=dev` - replace with the region you would like to deploy to and the name you want to associate with the cloudformation stack that the CDK will deploy.
 
-7. (Optional) Set the optional feature to deploy the Point Cloud (PC) visualizer pipeline with environment variables `export pipelineActivatePCVisualizer=true` - the point cloud (PC) visualizer pipeline stack is for viewing Point Cloud files in the VAMS visualizer preview. You can optionally set this via CDK deploy context parameter. Note: This does deploy additional AWS components such as a VPC and EPV endpoints that may have additional static infrastructure costs.
+7. (Optional) Set the optional feature to deploy the Point Cloud (PC) visualizer pipeline with environment variables `export PIPELINEACTIVATE_PCVISUALIZER=true` - the point cloud (PC) visualizer pipeline stack is for viewing Point Cloud files in the VAMS visualizer preview. You can optionally set this via CDK deploy context parameter. Note: This does deploy additional AWS components such as a VPC and EPV endpoints that may have additional static infrastructure costs.
 
 8. `npm run deploy.dev adminEmailAddress=myuser@example.com` - replace with your email address to deploy. An account is created in an AWS Cognito User Pool using this email address. Expect an email from no-reply@verificationemail.com with a temporary password.
 
@@ -185,7 +185,7 @@ To know more about how VAMS works and for instructions on configuring pipeline &
 
 # Writing your own VAMS pipelines
 
-Refer to the ![Writing your own pipelines section in the Developer Guide](./DeveloperGuide.md/#adding-your-own-pipelines).
+Refer to the [Writing your own pipelines section in the Developer Guide](./DeveloperGuide.md/#adding-your-own-pipelines).
 
 ## Security
 

--- a/backendVisualizerPipelines/pc/Dockerfile_Potree
+++ b/backendVisualizerPipelines/pc/Dockerfile_Potree
@@ -1,15 +1,17 @@
 # Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-alpine
+FROM --platform=linux/amd64 python:3.11-alpine
 
 #Build PotreeConverter
 WORKDIR /PotreeConverterBuild
 
-# install build deps, download Potree Source, and build for Potree Conveter
+# install build deps, download Potree Source, and build for Potree Converter
+# Note. We are cloning to a depth of 5 which must include the git SHA below (see 
+# git reset --hard below). So, if more commits are made to the PoTree repository we
+# will need to increase the clone depth
 RUN apk add --no-cache git cmake make gcc g++ libtbb-dev && \
-    git clone --depth 1 --branch $VERSION https://github.com/potree/PotreeConverter /PotreeConverter || \
-    git clone --depth 1 https://github.com/potree/PotreeConverter /PotreeConverter
+    git clone --depth 5 https://github.com/potree/PotreeConverter /PotreeConverter
 
 # Copy a git patch for the local CMakeLists.txt so we can override compiler settings
 COPY ./PotreeConverter-Fork_af4666fa.patch /PotreeConverter/vams-potree-build.patch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Forced platform to linux/amd64 for the PoTree docker image
- ensured that build happens from the commit hash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
